### PR TITLE
Fix initial liquidity locking

### DIFF
--- a/elrond_dex_farm/src/lib.rs
+++ b/elrond_dex_farm/src/lib.rs
@@ -221,10 +221,10 @@ pub trait Farm {
             entering_epoch: self.blockchain().get_block_epoch(),
         };
 
-        // Do the actual permanent lock of first minimul liquidity
+        // Do the actual permanent lock of first minimum liquidity
         // only after the token attributes are crafted for the user.
         if is_first_provider {
-            liquidity -= BigUint::from(self.liquidity_pool().minimul_liquidity_farm_amount());
+            liquidity -= BigUint::from(self.liquidity_pool().minimum_liquidity_farm_amount());
         }
 
         // This 1 is necessary to get_esdt_token_data needed for calculateRewardsForGivenPosition
@@ -664,7 +664,7 @@ pub trait Farm {
         let farming_pool_token_nonce = self.farm_token_nonce().get();
 
         if is_first_provider {
-            liquidity -= BigUint::from(self.liquidity_pool().minimul_liquidity_farm_amount());
+            liquidity -= BigUint::from(self.liquidity_pool().minimum_liquidity_farm_amount());
         }
 
         Ok(SftTokenAmountPair {

--- a/elrond_dex_farm/src/lib.rs
+++ b/elrond_dex_farm/src/lib.rs
@@ -206,8 +206,9 @@ pub trait Farm {
             "Cannot farm with amount of 0"
         );
 
+        let is_first_provider = self.liquidity_pool().is_first_provider();
         let farming_pool_token_id = self.farming_pool_token_id().get();
-        let liquidity = sc_try!(self.liquidity_pool().add_liquidity(
+        let mut liquidity = sc_try!(self.liquidity_pool().add_liquidity(
             farm_contribution.clone(),
             farming_pool_token_id,
             token_in.clone()
@@ -219,6 +220,12 @@ pub trait Farm {
             total_amount_liquidity: liquidity.clone(),
             entering_epoch: self.blockchain().get_block_epoch(),
         };
+
+        // Do the actual permanent lock of first minimul liquidity
+        // only after the token attributes are crafted for the user.
+        if is_first_provider {
+            liquidity -= BigUint::from(self.liquidity_pool().minimul_liquidity_farm_amount());
+        }
 
         // This 1 is necessary to get_esdt_token_data needed for calculateRewardsForGivenPosition
         let farm_tokens_to_create = liquidity.clone() + BigUint::from(1u64);
@@ -233,13 +240,11 @@ pub trait Farm {
             &self.blockchain().get_caller(),
         );
 
-        Ok(
-            SftTokenAmountPair {
-                token_id: farm_token_id,
-                token_nonce: farm_token_nonce,
-                amount: liquidity,
-            }
-        )
+        Ok(SftTokenAmountPair {
+            token_id: farm_token_id,
+            token_nonce: farm_token_nonce,
+            amount: liquidity,
+        })
     }
 
     #[payable("*")]
@@ -279,11 +284,11 @@ pub trait Farm {
         if self.should_apply_penalty(farm_attributes.entering_epoch) {
             let mut penalty_amount = self.get_penalty_amount(reward.clone());
             self.burn_tokens(&farming_pool_token_id, 0, &penalty_amount);
-            reward = reward - penalty_amount;
+            reward -= penalty_amount;
 
             penalty_amount = self.get_penalty_amount(farmed_token_amount.clone());
             self.burn_tokens(&farm_attributes.farmed_token_id, 0, &penalty_amount);
-            farmed_token_amount = farmed_token_amount - penalty_amount;
+            farmed_token_amount -= penalty_amount;
         }
 
         self.send_tokens(
@@ -649,13 +654,19 @@ pub trait Farm {
         let farm_contribution = sc_try!(self.get_farm_contribution(&token_in, &amount_in));
         let farming_pool_token_id = self.farming_pool_token_id().get();
 
-        let liquidity = self.liquidity_pool().calculate_liquidity(
+        let is_first_provider = self.liquidity_pool().is_first_provider();
+        let mut liquidity = self.liquidity_pool().calculate_liquidity(
             &farm_contribution,
             &farming_pool_token_id,
             &token_in,
         );
         let farm_token_id = self.farm_token_id().get();
         let farming_pool_token_nonce = self.farm_token_nonce().get();
+
+        if is_first_provider {
+            liquidity -= BigUint::from(self.liquidity_pool().minimul_liquidity_farm_amount());
+        }
+
         Ok(SftTokenAmountPair {
             token_id: farm_token_id,
             token_nonce: farming_pool_token_nonce + 1,

--- a/elrond_dex_farm/src/liquidity_pool.rs
+++ b/elrond_dex_farm/src/liquidity_pool.rs
@@ -23,12 +23,10 @@ pub trait LiquidityPoolModule {
 
         let mut total_supply = self.total_supply().get();
         if total_supply == 0 {
-            let minimum_amount = BigUint::from(MINIMUM_INITIAL_FARM_AMOUNT);
             require!(
                 liquidity > MINIMUM_INITIAL_FARM_AMOUNT,
                 "First farm needs to be greater than minimum amount"
             );
-            total_supply = minimum_amount;
         }
 
         let is_virtual_amount = farming_pool_token_id != farmed_token_id;
@@ -60,6 +58,10 @@ pub trait LiquidityPoolModule {
         let is_virtual_amount = farming_pool_token_id != farmed_token_id;
         if is_virtual_amount {
             let mut virtual_reserves = self.virtual_reserves().get();
+            require!(
+                virtual_reserves > initial_worth,
+                "Removing more virtual amount than available"
+            );
             virtual_reserves -= initial_worth;
             self.virtual_reserves().set(&virtual_reserves);
         }
@@ -92,12 +94,19 @@ pub trait LiquidityPoolModule {
         }
 
         if total_supply == 0 {
-            let minimum_amount = BigUint::from(MINIMUM_INITIAL_FARM_AMOUNT);
-            amount - &minimum_amount
+            amount.clone()
         } else {
             let total_reserves = virtual_reserves + actual_reserves + reward_amount;
             amount * &total_supply / total_reserves
         }
+    }
+
+    fn is_first_provider(&self) -> bool {
+        self.total_supply().get() == 0
+    }
+
+    fn minimul_liquidity_farm_amount(&self) -> u64 {
+        MINIMUM_INITIAL_FARM_AMOUNT
     }
 
     #[view(getTotalSupply)]

--- a/elrond_dex_farm/src/liquidity_pool.rs
+++ b/elrond_dex_farm/src/liquidity_pool.rs
@@ -105,7 +105,7 @@ pub trait LiquidityPoolModule {
         self.total_supply().get() == 0
     }
 
-    fn minimul_liquidity_farm_amount(&self) -> u64 {
+    fn minimum_liquidity_farm_amount(&self) -> u64 {
         MINIMUM_INITIAL_FARM_AMOUNT
     }
 

--- a/elrond_dex_farm/src/rewards.rs
+++ b/elrond_dex_farm/src/rewards.rs
@@ -64,11 +64,6 @@ pub trait RewardsModuleImpl {
         );
 
         let virtual_reserves = self.liquidity_pool().virtual_reserves().get();
-        require!(
-            virtual_reserves > initial_worth,
-            "Removing more virtual reserve than existent"
-        );
-
         let actual_reserves = self.blockchain().get_esdt_balance(
             &self.blockchain().get_sc_address(),
             token_id.as_esdt_identifier(),


### PR DESCRIPTION
This is the correct way we want to lock the initial liquidity. Before this commit, because all the information is stored inside the SFT, the first "farmer" could exit farm and actually get all his initial tokens. This is the normal case except for the first one. For the first one, because of liquidity calculations, we need to permanently lock a part of first input tokens. 
In this fix, the liquidity is locked only after the SFT attributes are crafted, which is essential. Now the first minimum amount will never be moved.