### PR TITLE
Audit fixing

### DIFF
--- a/dex/elrond_dex_router/src/lib.rs
+++ b/dex/elrond_dex_router/src/lib.rs
@@ -109,8 +109,14 @@ pub trait Router: factory::FactoryModule {
         #[payment] issue_cost: Self::BigUint,
     ) -> SCResult<AsyncCall<Self::SendApi>> {
         require!(self.is_active(), "Not active");
-        self.check_is_pair_sc(&pair_address)?;
         let caller = self.blockchain().get_caller();
+        if caller != owner {
+            require!(
+                self.pair_creation_enabled().get(),
+                "Pair creation is disabled"
+            );
+        }
+        self.check_is_pair_sc(&pair_address)?;
         let result = self.get_pair_temporary_owner(&pair_address);
 
         match result {

--- a/dex/elrond_dex_router/src/lib.rs
+++ b/dex/elrond_dex_router/src/lib.rs
@@ -110,7 +110,7 @@ pub trait Router: factory::FactoryModule {
     ) -> SCResult<AsyncCall<Self::SendApi>> {
         require!(self.is_active(), "Not active");
         let caller = self.blockchain().get_caller();
-        if caller != owner {
+        if caller != self.owner().get() {
             require!(
                 self.pair_creation_enabled().get(),
                 "Pair creation is disabled"

--- a/dex/mandos/check_fee_enabled_after_swap.scen.json
+++ b/dex/mandos/check_fee_enabled_after_swap.scen.json
@@ -49,7 +49,7 @@
 						"str:router_address": "sc:router_contract",
 						"str:state": "1",
 						"str:owner": "address:owner",
-						"str:temporary_fee_storage": "199",
+						"str:current_block_fee_storage": "0x01000000000000000000000001c7",
 						"str:minimum_farming_epochs": "2",
 						"str:burn_tokens_gas_limit": "5,000,000",
 						"str:mint_tokens_gas_limit": "5,000,000",

--- a/dex/mandos/farm_reward_distr_scen_5.scen.json
+++ b/dex/mandos/farm_reward_distr_scen_5.scen.json
@@ -1,0 +1,254 @@
+{
+	"name": "accept esdt payment",
+	"steps": [
+		{
+			"step": "setState",
+			"currentBlockInfo": {
+				"blockNonce": "0"
+			}
+		},
+		{
+			"step": "setState",
+			"accounts": {
+				"address:alice": {
+					"nonce": "0",
+					"balance": "1,000,000,000,000",
+					"esdt": {
+						"str:LPTOK-abcdef": "1,000"
+					},
+					"storage": {}
+				},
+				"address:bob": {
+					"nonce": "0",
+					"balance": "1,000,000,000,000",
+					"esdt": {
+						"str:LPTOK-abcdef": "1,000"
+					},
+					"storage": {}
+				},
+				"address:other_account": {
+					"nonce": "0",
+					"balance": "1,000,000,000,000",
+					"esdt": {
+						"str:MEX-abcdef": "1,000"
+					},
+					"storage": {}
+				},
+				"sc:farm_contract": {
+					"nonce": "0",
+					"balance": "0",
+					"esdt": {
+						"str:FARM-abcdef": {
+							"roles": [
+								"ESDTRoleNFTCreate",
+								"ESDTRoleNFTAddQuantity",
+								"ESDTRoleNFTBurn"
+							]
+						},
+						"str:LPTOK-abcdef": {
+							"roles": [
+								"ESDTRoleLocalBurn"
+							]
+						},
+						"str:MEX-abcdef": {
+							"roles": [
+								"ESDTRoleLocalMint",
+								"ESDTRoleLocalBurn"
+							]
+						}
+					},
+					"storage": {
+						"str:farming_token_id": "str:LPTOK-abcdef",
+						"str:farm_token_id": "str:FARM-abcdef",
+						"str:reward_token_id": "str:MEX-abcdef",
+						"str:state": "1",
+						"str:minimum_farming_epochs": "2",
+						"str:burn_tokens_gas_limit": "5,000,000",
+						"str:mint_tokens_gas_limit": "5,000,000",
+						"str:penalty_percent": "0",
+						"str:division_safety_constant": "1000000000000",
+						"str:per_block_reward_amount": "100",
+						"str:produce_rewards_enabled": "1",
+						"str:create_farm_tokens_gas_limit": "5000000"
+					},
+					"code": "file:../elrond_dex_farm/output/elrond_dex_farm.wasm",
+					"owner": "address:owner"
+				}
+			}
+		},
+		{
+			"step": "setState",
+			"currentBlockInfo": {
+				"blockNonce": "1"
+			}
+		},
+		{
+			"step": "scCall",
+			"txId": "alice-enters",
+			"tx": {
+				"from": "address:alice",
+				"to": "sc:farm_contract",
+				"value": "0",
+				"function": "enterFarm",
+				"esdt": {
+					"tokenIdentifier": "str:LPTOK-abcdef",
+					"value": "1,000"
+				},
+				"arguments": [],
+				"gasLimit": "100,000,000",
+				"gasPrice": "0"
+			},
+			"expect": {
+				"out": [
+					"0x01",
+					"0x0000000b4641524d2d61626364656600000000000000010000000203e8"
+				],
+				"status": "0",
+				"message": "",
+				"gas": "*",
+				"refund": "*"
+			}
+		},
+		{
+			"step": "setState",
+			"currentBlockInfo": {
+				"blockNonce": "2"
+			}
+		},
+		{
+			"step": "scCall",
+			"txId": "bob-enters",
+			"tx": {
+				"from": "address:bob",
+				"to": "sc:farm_contract",
+				"value": "0",
+				"function": "enterFarm",
+				"esdt": {
+					"tokenIdentifier": "str:LPTOK-abcdef",
+					"value": "1,000"
+				},
+				"arguments": [],
+				"gasLimit": "100,000,000",
+				"gasPrice": "0"
+			},
+			"expect": {
+				"out": [
+					"0x02",
+					"0x0000000b4641524d2d61626364656600000000000000020000000203e8"
+				],
+				"status": "0",
+				"message": "",
+				"gas": "*",
+				"refund": "*"
+			}
+		},
+		{
+			"step": "setState",
+			"currentBlockInfo": {
+				"blockNonce": "9"
+			}
+		},
+		{
+			"step": "scCall",
+			"txId": "accept-fee",
+			"tx": {
+				"from": "address:other_account",
+				"to": "sc:farm_contract",
+				"value": "0",
+				"function": "acceptFee",
+				"esdt": {
+					"tokenIdentifier": "str:MEX-abcdef",
+					"value": "1,000"
+				},
+				"arguments": [],
+				"gasLimit": "100,000,000",
+				"gasPrice": "0"
+			},
+			"expect": {
+				"out": [],
+				"status": "0",
+				"message": "",
+				"gas": "*",
+				"refund": "*"
+			}
+		},
+		{
+			"step": "scCall",
+			"txId": "alice-exits",
+			"tx": {
+				"from": "address:alice",
+				"to": "sc:farm_contract",
+				"value": "0",
+				"function": "exitFarm",
+				"esdt": {
+					"tokenIdentifier": "str:FARM-abcdef",
+					"nonce": "1",
+					"value": "1,000"
+				},
+				"arguments": [],
+				"gasLimit": "100,000,000",
+				"gasPrice": "0"
+			},
+			"expect": {
+				"out": [
+					"0x0000000c4c50544f4b2d6162636465660000000203e8",
+					"0x0000000a4d45582d61626364656600000000000000000000000201c2"
+				],
+				"status": "0",
+				"message": "",
+				"gas": "*",
+				"refund": "*"
+			}
+		},
+		{
+			"step": "scCall",
+			"txId": "bob-exits",
+			"tx": {
+				"from": "address:bob",
+				"to": "sc:farm_contract",
+				"value": "0",
+				"function": "exitFarm",
+				"esdt": {
+					"tokenIdentifier": "str:FARM-abcdef",
+					"nonce": "2",
+					"value": "1,000"
+				},
+				"arguments": [],
+				"gasLimit": "100,000,000",
+				"gasPrice": "0"
+			},
+			"expect": {
+				"out": [
+					"0x0000000c4c50544f4b2d6162636465660000000203e8",
+					"0x0000000a4d45582d616263646566000000000000000000000002015e"
+				],
+				"status": "0",
+				"message": "",
+				"gas": "*",
+				"refund": "*"
+			}
+		},
+		{
+			"step": "checkState",
+			"accounts": {
+				"address:alice": {
+					"nonce": "2",
+					"balance": "1,000,000,000,000",
+					"esdt": {
+						"str:LPTOK-abcdef": "1,000",
+						"str:MEX-abcdef": "450"
+					}
+				},
+				"address:bob": {
+					"nonce": "2",
+					"balance": "1,000,000,000,000",
+					"esdt": {
+						"str:LPTOK-abcdef": "1,000",
+						"str:MEX-abcdef": "350"
+					}
+				},
+				"+": ""
+			}
+		}
+	]
+}

--- a/distribution/distrib-common/src/lib.rs
+++ b/distribution/distrib-common/src/lib.rs
@@ -43,6 +43,6 @@ pub struct WrappedLpTokenAttributes<BigUint: BigUintApi> {
 pub struct WrappedFarmTokenAttributes {
     pub farm_token_id: TokenIdentifier,
     pub farm_token_nonce: Nonce,
-    pub farmed_token_id: TokenIdentifier,
-    pub farmed_token_nonce: Nonce,
+    pub farming_token_id: TokenIdentifier,
+    pub farming_token_nonce: Nonce,
 }

--- a/distribution/distrib-common/src/lib.rs
+++ b/distribution/distrib-common/src/lib.rs
@@ -35,7 +35,6 @@ pub struct LockedTokenAttributes {
 pub struct WrappedLpTokenAttributes<BigUint: BigUintApi> {
     pub lp_token_id: TokenIdentifier,
     pub lp_token_total_amount: BigUint,
-    pub locked_assets_token_id: TokenIdentifier,
     pub locked_assets_invested: BigUint,
     pub locked_assets_nonce: Nonce,
 }

--- a/distribution/mandos/steps/deploy.steps.json
+++ b/distribution/mandos/steps/deploy.steps.json
@@ -144,30 +144,9 @@
                 "contractCode": "file:../../sc-proxy-dex/output/sc-proxy-dex.wasm",
                 "arguments": [
                     "str:MEX-abcdef",
+                    "str:LKMEX-abcdef",
                     "0x0000000008FFFFFF00000000017D784000000000017D7840000000000FFFE10000000000004C4B4000000000004C4B40",
                     "0x0000000010FFFFFF0000000010FFFFFF0000000010FFFFFF00000000004C4B4000000000004C4B40"
-                ],
-                "gasLimit": "100,000,000",
-                "gasPrice": "0"
-            },
-            "expect": {
-                "out": [],
-                "status": "",
-                "logs": [],
-                "gas": "*",
-                "refund": "*"
-            }
-        },
-        {
-            "step": "scCall",
-            "txId": "2",
-            "tx": {
-                "from": "address:owner",
-                "to": "sc:proxy_dex_contract",
-                "value": "0",
-                "function": "addAcceptedLockedAssetTokenId",
-                "arguments": [
-                    "str:LKMEX-abcdef"
                 ],
                 "gasLimit": "100,000,000",
                 "gasPrice": "0"
@@ -274,6 +253,7 @@
                         "str:wrapped_farm_token_nonce": "0",
                         "str:proxy_pair_params": "0x0000000008FFFFFF00000000017D784000000000017D7840000000000FFFE10000000000004C4B4000000000004C4B40",
                         "str:distributed_token_id": "str:MEX-abcdef",
+                        "str:locked_asset_token_id": "str:LKMEX-abcdef",
                         "str:accepted_locked_assets.info": "0x00000002000000010000000200000002",
                         "str:accepted_locked_assets.node_idLKMEX-abcdef": "1",
                         "str:accepted_locked_assets.node_idLKMEX2-abcdef": "2",

--- a/distribution/sc-proxy-dex/src/lib.rs
+++ b/distribution/sc-proxy-dex/src/lib.rs
@@ -24,10 +24,12 @@ pub trait ProxyDexImpl:
     fn init(
         &self,
         asset_token_id: TokenIdentifier,
+        locked_asset_token_id: TokenIdentifier,
         proxy_pair_params: ProxyPairParams,
         proxy_farm_params: ProxyFarmParams,
     ) {
         self.asset_token_id().set(&asset_token_id);
+        self.locked_asset_token_id().set(&&locked_asset_token_id);
         self.init_proxy_pair(proxy_pair_params);
         self.init_proxy_farm(proxy_farm_params);
     }

--- a/distribution/sc-proxy-dex/src/proxy_common.rs
+++ b/distribution/sc-proxy-dex/src/proxy_common.rs
@@ -8,29 +8,6 @@ const MAX_FUNDS_EXTRIES: usize = 10;
 
 #[elrond_wasm_derive::module]
 pub trait ProxyCommonModule {
-    #[endpoint(addAcceptedLockedAssetTokenId)]
-    fn add_accepted_locked_asset_token_id(&self, token_id: TokenIdentifier) -> SCResult<()> {
-        self.require_permissions()?;
-        self.accepted_locked_assets().insert(token_id);
-        Ok(())
-    }
-
-    #[endpoint(removeAcceptedLockedAssetTokenId)]
-    fn remove_accepted_locked_asset_token_id(&self, token_id: TokenIdentifier) -> SCResult<()> {
-        self.require_permissions()?;
-        self.require_is_accepted_locked_asset(&token_id)?;
-        self.accepted_locked_assets().remove(&token_id);
-        Ok(())
-    }
-
-    fn require_is_accepted_locked_asset(&self, token_id: &TokenIdentifier) -> SCResult<()> {
-        require!(
-            self.accepted_locked_assets().contains(token_id),
-            "Not an accepted locked asset"
-        );
-        Ok(())
-    }
-
     fn require_permissions(&self) -> SCResult<()> {
         only_owner!(self, "Permission denied");
         Ok(())
@@ -146,10 +123,9 @@ pub trait ProxyCommonModule {
         &self,
     ) -> MapMapper<Self::Storage, (TokenIdentifier, Nonce), Self::BigUint>;
 
-    #[view(getAcceptedLockedAssetsTokenIds)]
-    #[storage_mapper("accepted_locked_assets")]
-    fn accepted_locked_assets(&self) -> SetMapper<Self::Storage, TokenIdentifier>;
-
     #[storage_mapper("distributed_token_id")]
     fn asset_token_id(&self) -> SingleValueMapper<Self::Storage, TokenIdentifier>;
+
+    #[storage_mapper("locked_asset_token_id")]
+    fn locked_asset_token_id(&self) -> SingleValueMapper<Self::Storage, TokenIdentifier>;
 }

--- a/distribution/sc-proxy-dex/src/proxy_common.rs
+++ b/distribution/sc-proxy-dex/src/proxy_common.rs
@@ -4,7 +4,7 @@ elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
 type Nonce = u64;
-const MAX_FUNDS_EXTRIES: usize = 10;
+const MAX_FUNDS_ENTRIES: usize = 10;
 
 #[elrond_wasm_derive::module]
 pub trait ProxyCommonModule {
@@ -20,7 +20,7 @@ pub trait ProxyCommonModule {
         #[payment_token] token_id: TokenIdentifier,
         #[payment] amount: Self::BigUint,
     ) {
-        if self.current_tx_accepted_funds().len() > MAX_FUNDS_EXTRIES {
+        if self.current_tx_accepted_funds().len() > MAX_FUNDS_ENTRIES {
             self.current_tx_accepted_funds().clear();
         }
 

--- a/distribution/sc-proxy-dex/src/proxy_farm.rs
+++ b/distribution/sc-proxy-dex/src/proxy_farm.rs
@@ -130,8 +130,8 @@ pub trait ProxyFarmModule: proxy_common::ProxyCommonModule + proxy_pair::ProxyPa
         let attributes = WrappedFarmTokenAttributes {
             farm_token_id,
             farm_token_nonce,
-            farmed_token_id: token_id,
-            farmed_token_nonce: token_nonce,
+            farming_token_id: token_id,
+            farming_token_nonce: token_nonce,
         };
         let caller = self.blockchain().get_caller();
         self.create_and_send_wrapped_farm_tokens(&attributes, &farm_token_total_amount, &caller);
@@ -174,14 +174,14 @@ pub trait ProxyFarmModule: proxy_common::ProxyCommonModule + proxy_pair::ProxyPa
                 &proxy_params,
             )
             .into_tuple();
-        let farmed_token_returned = farm_result.0;
+        let farming_token_returned = farm_result.0;
         let reward_token_returned = farm_result.1;
         self.validate_received_funds_chunk(
             [
                 (
-                    &farmed_token_returned.token_id,
+                    &farming_token_returned.token_id,
                     0,
-                    &farmed_token_returned.amount,
+                    &farming_token_returned.amount,
                 ),
                 (
                     &reward_token_returned.token_id,
@@ -194,9 +194,9 @@ pub trait ProxyFarmModule: proxy_common::ProxyCommonModule + proxy_pair::ProxyPa
 
         let caller = self.blockchain().get_caller();
         self.send().transfer_tokens(
-            &wrapped_farm_token_attrs.farmed_token_id,
-            wrapped_farm_token_attrs.farmed_token_nonce,
-            &farmed_token_returned.amount,
+            &wrapped_farm_token_attrs.farming_token_id,
+            wrapped_farm_token_attrs.farming_token_nonce,
+            &farming_token_returned.amount,
             &caller,
         );
 
@@ -212,11 +212,11 @@ pub trait ProxyFarmModule: proxy_common::ProxyCommonModule + proxy_pair::ProxyPa
             &amount,
             proxy_params.burn_tokens_gas_limit,
         );
-        if farmed_token_returned.token_id == self.asset_token_id().get() {
+        if farming_token_returned.token_id == self.asset_token_id().get() {
             self.send().burn_tokens(
-                &farmed_token_returned.token_id,
+                &farming_token_returned.token_id,
                 0,
-                &farmed_token_returned.amount,
+                &farming_token_returned.amount,
                 proxy_params.burn_tokens_gas_limit,
             );
         }
@@ -304,8 +304,8 @@ pub trait ProxyFarmModule: proxy_common::ProxyCommonModule + proxy_pair::ProxyPa
         let new_wrapped_farm_token_attributes = WrappedFarmTokenAttributes {
             farm_token_id: new_farm_token_id,
             farm_token_nonce: new_farm_token_nonce,
-            farmed_token_id: wrapped_farm_token_attrs.farmed_token_id,
-            farmed_token_nonce: wrapped_farm_token_attrs.farmed_token_nonce,
+            farming_token_id: wrapped_farm_token_attrs.farming_token_id,
+            farming_token_nonce: wrapped_farm_token_attrs.farming_token_nonce,
         };
         self.create_and_send_wrapped_farm_tokens(
             &new_wrapped_farm_token_attributes,


### PR DESCRIPTION
- Replaced Set of LockedAsset Token Ids with A single value mapper since it will only be one.
- Fixed the case where swap fees distribution were not calculated regardless of the events within a block
- Issue of LP token disabled for users while pair creation is disabled