### PR TITLE
Removed validate functions

### DIFF
--- a/distribution/sc-proxy-dex/src/proxy_common.rs
+++ b/distribution/sc-proxy-dex/src/proxy_common.rs
@@ -4,7 +4,6 @@ elrond_wasm::derive_imports!();
 use common_structs::Nonce;
 use common_structs::{WrappedFarmTokenAttributes, WrappedLpTokenAttributes};
 
-const MAX_FUNDS_ENTRIES: usize = 10;
 pub const ACCEPT_PAY_FUNC_NAME: &[u8] = b"acceptPay";
 
 #[elrond_wasm_derive::module]
@@ -16,104 +15,7 @@ pub trait ProxyCommonModule {
 
     #[payable("*")]
     #[endpoint(acceptPay)]
-    fn accept_pay(
-        &self,
-        #[payment_token] token_id: TokenIdentifier,
-        #[payment_amount] amount: Self::BigUint,
-        #[payment_nonce] token_nonce: Nonce,
-    ) {
-        if amount == 0 {
-            return;
-        }
-
-        if self.current_tx_accepted_funds().len() > MAX_FUNDS_ENTRIES {
-            self.current_tx_accepted_funds().clear();
-        }
-
-        let entry = self
-            .current_tx_accepted_funds()
-            .get(&(token_id.clone(), token_nonce));
-        match entry {
-            Some(value) => {
-                self.current_tx_accepted_funds()
-                    .insert((token_id, token_nonce), value + amount);
-            }
-            None => {
-                self.current_tx_accepted_funds()
-                    .insert((token_id, token_nonce), amount);
-            }
-        }
-    }
-
-    fn reset_received_funds_on_current_tx(&self) {
-        self.current_tx_accepted_funds().clear();
-    }
-
-    fn validate_received_funds_chunk(
-        &self,
-        received_funds: Vec<(&TokenIdentifier, Nonce, &Self::BigUint)>,
-    ) -> SCResult<()> {
-        let big_zero = Self::BigUint::zero();
-
-        for funds in received_funds {
-            let token_id = funds.0;
-            let nonce = funds.1;
-            let amount = funds.2;
-
-            if amount == &big_zero {
-                continue;
-            }
-
-            self.validate_received_funds_on_current_tx(token_id, nonce, amount)?;
-            let old_amount = self
-                .current_tx_accepted_funds()
-                .get(&(token_id.clone(), nonce))
-                .unwrap();
-
-            if &old_amount == amount {
-                self.current_tx_accepted_funds()
-                    .remove(&(token_id.clone(), nonce));
-            } else {
-                self.current_tx_accepted_funds()
-                    .insert((token_id.clone(), nonce), &old_amount - amount);
-            }
-        }
-
-        require!(
-            self.current_tx_accepted_funds().is_empty(),
-            "More funds were received"
-        );
-
-        Ok(())
-    }
-
-    fn validate_received_funds_on_current_tx(
-        &self,
-        token_id: &TokenIdentifier,
-        token_nonce: Nonce,
-        amount: &Self::BigUint,
-    ) -> SCResult<()> {
-        if amount == &Self::BigUint::zero() {
-            return Ok(());
-        }
-
-        let result = self
-            .current_tx_accepted_funds()
-            .get(&(token_id.clone(), token_nonce));
-
-        match result {
-            Some(available_amount) => {
-                if &available_amount >= amount {
-                    Ok(())
-                } else {
-                    sc_error!("Available amount is not enough")
-                }
-            }
-            None => {
-                sc_error!("No available funds of this type")
-            }
-        }
-    }
+    fn accept_pay(&self) {}
 
     fn direct_generic(
         &self,

--- a/distribution/sc-proxy-dex/src/proxy_farm.rs
+++ b/distribution/sc-proxy-dex/src/proxy_farm.rs
@@ -106,7 +106,6 @@ pub trait ProxyFarmModule:
             return sc_error!("Unknown input Token");
         }
 
-        self.reset_received_funds_on_current_tx();
         let farm_result =
             self.actual_enter_farm(&farm_address, &farming_token_id, &amount, with_lock_rewards);
         let farm_token_id = farm_result.token_id;
@@ -116,9 +115,6 @@ pub trait ProxyFarmModule:
             farm_token_total_amount > 0,
             "Farm token amount received should be greater than 0"
         );
-        self.validate_received_funds_chunk(
-            [(&farm_token_id, farm_token_nonce, &farm_token_total_amount)].to_vec(),
-        )?;
 
         let attributes = WrappedFarmTokenAttributes {
             farm_token_id,
@@ -162,27 +158,11 @@ pub trait ProxyFarmModule:
         let farm_token_id = wrapped_farm_token_attrs.farm_token_id;
         let farm_token_nonce = wrapped_farm_token_attrs.farm_token_nonce;
 
-        self.reset_received_funds_on_current_tx();
         let farm_result = self
             .actual_exit_farm(farm_address, &farm_token_id, farm_token_nonce, &amount)
             .into_tuple();
         let farming_token_returned = farm_result.0;
         let reward_token_returned = farm_result.1;
-        self.validate_received_funds_chunk(
-            [
-                (
-                    &farming_token_returned.token_id,
-                    0,
-                    &farming_token_returned.amount,
-                ),
-                (
-                    &reward_token_returned.token_id,
-                    reward_token_returned.token_nonce,
-                    &reward_token_returned.amount,
-                ),
-            ]
-            .to_vec(),
-        )?;
 
         let caller = self.blockchain().get_caller();
         self.send().direct_nft(
@@ -235,7 +215,6 @@ pub trait ProxyFarmModule:
         let farm_token_id = wrapped_farm_token_attrs.farm_token_id;
         let farm_token_nonce = wrapped_farm_token_attrs.farm_token_nonce;
 
-        self.reset_received_funds_on_current_tx();
         let result = self
             .actual_claim_rewards(&farm_address, &farm_token_id, farm_token_nonce, &amount)
             .into_tuple();
@@ -248,21 +227,6 @@ pub trait ProxyFarmModule:
             new_farm_token_total_amount > 0,
             "Farm token amount received should be greater than 0"
         );
-        self.validate_received_funds_chunk(
-            [
-                (
-                    &new_farm_token_id,
-                    new_farm_token_nonce,
-                    &new_farm_token_total_amount,
-                ),
-                (
-                    &reward_token_returned.token_id,
-                    reward_token_returned.token_nonce,
-                    &reward_token_returned.amount,
-                ),
-            ]
-            .to_vec(),
-        )?;
 
         // Send the reward to the caller.
         let caller = self.blockchain().get_caller();
@@ -318,7 +282,6 @@ pub trait ProxyFarmModule:
         let farm_token_nonce = wrapped_farm_token_attrs.farm_token_nonce;
         let farm_amount = payment_amount.clone();
 
-        self.reset_received_funds_on_current_tx();
         let result = self.actual_compound_rewards(
             &farm_address,
             &farm_token_id,
@@ -334,14 +297,6 @@ pub trait ProxyFarmModule:
             new_farm_token_amount > 0,
             "Farm token amount received should be greater than 0"
         );
-        self.validate_received_funds_chunk(
-            [(
-                &new_farm_token_id,
-                new_farm_token_nonce,
-                &new_farm_token_amount,
-            )]
-            .to_vec(),
-        )?;
 
         let new_wrapped_farm_token_attributes = WrappedFarmTokenAttributes {
             farm_token_id: new_farm_token_id,

--- a/distribution/sc-proxy-dex/src/proxy_pair.rs
+++ b/distribution/sc-proxy-dex/src/proxy_pair.rs
@@ -189,7 +189,6 @@ pub trait ProxyPairModule:
         );
 
         // Actual adding of liquidity
-        self.reset_received_funds_on_current_tx();
         let result = self.actual_add_liquidity(
             &pair_address,
             &first_token_amount_desired,
@@ -216,22 +215,6 @@ pub trait ProxyPairModule:
                 && second_token_used.amount <= second_token_amount_desired,
             "Used more tokens than provided"
         );
-        self.validate_received_funds_chunk(
-            [
-                (&lp_received.token_id, 0, &lp_received.amount),
-                (
-                    &first_token_used.token_id,
-                    0,
-                    &(&first_token_amount_desired - &first_token_used.amount),
-                ),
-                (
-                    &second_token_used.token_id,
-                    0,
-                    &(&second_token_amount_desired - &second_token_used.amount),
-                ),
-            ]
-            .to_vec(),
-        )?;
 
         //Recalculate temporary funds and burn unused
         let locked_asset_token_nonce: Nonce;
@@ -324,7 +307,6 @@ pub trait ProxyPairModule:
         let locked_asset_token_id = self.locked_asset_token_id().get();
         let asset_token_id = self.asset_token_id().get();
 
-        self.reset_received_funds_on_current_tx();
         let tokens_for_position = self
             .actual_remove_liquidity(
                 &pair_address,
@@ -334,21 +316,6 @@ pub trait ProxyPairModule:
                 &second_token_amount_min,
             )
             .into_tuple();
-        self.validate_received_funds_chunk(
-            [
-                (
-                    &tokens_for_position.0.token_id,
-                    0,
-                    &tokens_for_position.0.amount,
-                ),
-                (
-                    &tokens_for_position.1.token_id,
-                    0,
-                    &tokens_for_position.1.amount,
-                ),
-            ]
-            .to_vec(),
-        )?;
 
         let fungible_token_id: TokenIdentifier;
         let fungible_token_amount: Self::BigUint;


### PR DESCRIPTION
Added a check for Error on Token Send. So the sender can safely check errors on send and it's safe to use intra or cross shard. In this case having proxy dex and dex contracts in the same shard, the sender can check for errors and avoid the check code in proxy.