### PR TITLE
Add endpoint to set init epoch

### DIFF
--- a/locked-asset/factory/src/lib.rs
+++ b/locked-asset/factory/src/lib.rs
@@ -403,6 +403,13 @@ pub trait LockedAssetFactory:
         }
     }
 
+    #[only_owner]
+    #[endpoint(setInitEpoch)]
+    fn set_init_epoch(&self, init_epoch: Epoch) {
+        self.init_epoch()
+            .set(&init_epoch);
+    }
+
     #[view(getLastErrorMessage)]
     #[storage_mapper("last_error_message")]
     fn last_error_message(&self) -> SingleValueMapper<ManagedBuffer>;


### PR DESCRIPTION
- Init epoch is used to compute starting months for unlock amounts

Signed-off-by: Claudiu Ion Lataretu <claudiu.lataretu@gmail.com>