### PR TITLE
farm: add whitelisting addresses for farm endpoints

### DIFF
--- a/dex/farm/src/config.rs
+++ b/dex/farm/src/config.rs
@@ -146,4 +146,7 @@ pub trait ConfigModule: token_supply::TokenSupplyModule + token_send::TokenSendM
     #[view(getPairContractManagedAddress)]
     #[storage_mapper("pair_contract_address")]
     fn pair_contract_address(&self) -> SingleValueMapper<ManagedAddress>;
+
+    #[storage_mapper("whitelist")]
+    fn whitelist(&self) -> SetMapper<ManagedAddress>;
 }

--- a/dex/farm/wasm/src/lib.rs
+++ b/dex/farm/wasm/src/lib.rs
@@ -43,9 +43,11 @@ elrond_wasm_node::wasm_endpoints! {
         getState
         getTransferExecGasLimit
         getUndistributedFees
+        getWhitelistedManagedAddresses
         mergeFarmTokens
         pause
         registerFarmToken
+        removeWhitelist
         resume
         setLocalRolesFarmToken
         setPerBlockRewardAmount
@@ -54,5 +56,6 @@ elrond_wasm_node::wasm_endpoints! {
         set_penalty_percent
         set_transfer_exec_gas_limit
         start_produce_rewards
+        whitelist
     )
 }


### PR DESCRIPTION
- Address whitelisting is used for farm accepting LKMEX as farming token
where proxy will be whitelisted in farm contract

Signed-off-by: Claudiu Ion Lataretu <claudiu.lataretu@gmail.com>