### PR TITLE
staking farm fixes

### DIFF
--- a/dex/farm-staking-proxy/src/lib.rs
+++ b/dex/farm-staking-proxy/src/lib.rs
@@ -89,7 +89,7 @@ pub trait FarmStakingProxy:
             let attributes = self.get_dual_yield_token_attributes(p.token_nonce);
             staking_farm_tokens.push(EsdtTokenPayment::new(
                 staking_farm_token_id.clone(),
-                attributes.lp_farm_token_nonce,
+                attributes.staking_farm_token_nonce,
                 p.amount.clone(),
             ));
 


### PR DESCRIPTION
- fix wrong token nonce take from attributes for `stake_farm_tokens` in the proxy contract