### PR TITLE
move contract interactions to different file

### DIFF
--- a/dex/farm-staking-proxy/src/external_contracts_interactions.rs
+++ b/dex/farm-staking-proxy/src/external_contracts_interactions.rs
@@ -1,0 +1,229 @@
+elrond_wasm::imports!();
+
+use farm::farm_token_merge::ProxyTrait as _;
+use pair::safe_price::ProxyTrait as _;
+
+use crate::result_types::*;
+use farm_staking::{ClaimRewardsResultType, EnterFarmResultType, ExitFarmResultType};
+use pair::RemoveLiquidityResultType;
+
+pub type SafePriceResult<Api> = MultiResult2<EsdtTokenPayment<Api>, EsdtTokenPayment<Api>>;
+
+#[elrond_wasm::module]
+pub trait ExternalContractsInteractionsModule:
+    crate::lp_farm_token::LpFarmTokenModule + token_merge::TokenMergeModule
+{
+    // lp farm
+
+    fn lp_farm_claim_rewards(
+        &self,
+        lp_farm_tokens: PaymentsVec<Self::Api>,
+    ) -> LpFarmClaimRewardsResult<Self::Api> {
+        let lp_farm_address = self.lp_farm_address().get();
+        let lp_farm_result: ClaimRewardsResultType<Self::Api> = self
+            .lp_farm_proxy_obj(lp_farm_address)
+            .claim_rewards(OptionalArg::None)
+            .with_multi_token_transfer(lp_farm_tokens)
+            .execute_on_dest_context_custom_range(|_, after| (after - 2, after));
+        let (new_lp_farm_tokens, lp_farm_rewards) = lp_farm_result.into_tuple();
+
+        LpFarmClaimRewardsResult {
+            new_lp_farm_tokens,
+            lp_farm_rewards,
+        }
+    }
+
+    fn lp_farm_exit(
+        &self,
+        lp_farm_token_nonce: u64,
+        lp_farm_token_amount: BigUint,
+    ) -> LpFarmExitResult<Self::Api> {
+        let lp_farm_token_id = self.lp_farm_token_id().get();
+        let lp_farm_address = self.lp_farm_address().get();
+        let exit_farm_result: ExitFarmResultType<Self::Api> = self
+            .lp_farm_proxy_obj(lp_farm_address)
+            .exit_farm(OptionalArg::None)
+            .add_token_transfer(lp_farm_token_id, lp_farm_token_nonce, lp_farm_token_amount)
+            .execute_on_dest_context();
+        let (lp_tokens, lp_farm_rewards) = exit_farm_result.into_tuple();
+
+        LpFarmExitResult {
+            lp_tokens,
+            lp_farm_rewards,
+        }
+    }
+
+    fn merge_lp_farm_tokens(
+        &self,
+        base_lp_token: EsdtTokenPayment<Self::Api>,
+        mut additional_lp_tokens: ManagedVec<EsdtTokenPayment<Self::Api>>,
+    ) -> EsdtTokenPayment<Self::Api> {
+        if additional_lp_tokens.is_empty() {
+            return base_lp_token;
+        }
+
+        additional_lp_tokens.push(base_lp_token);
+
+        let lp_farm_address = self.lp_farm_address().get();
+        self.lp_farm_proxy_obj(lp_farm_address)
+            .merge_farm_tokens(OptionalArg::None)
+            .with_multi_token_transfer(additional_lp_tokens)
+            .execute_on_dest_context()
+    }
+
+    // staking farm
+
+    fn staking_farm_enter(
+        &self,
+        staking_token_amount: BigUint,
+        staking_farm_tokens: PaymentsVec<Self::Api>,
+    ) -> StakingFarmEnterResult<Self::Api> {
+        let staking_farm_address = self.staking_farm_address().get();
+        let received_staking_farm_token: EnterFarmResultType<Self::Api> = self
+            .staking_farm_proxy_obj(staking_farm_address)
+            .stake_farm_through_proxy(staking_token_amount)
+            .with_multi_token_transfer(staking_farm_tokens)
+            .execute_on_dest_context_custom_range(|_, after| (after - 1, after));
+
+        StakingFarmEnterResult {
+            received_staking_farm_token,
+        }
+    }
+
+    fn staking_farm_claim_rewards(
+        &self,
+        new_staking_farm_values: ManagedVec<BigUint>,
+        staking_farm_tokens: PaymentsVec<Self::Api>,
+    ) -> StakingFarmClaimRewardsResult<Self::Api> {
+        let staking_farm_address = self.staking_farm_address().get();
+        let staking_farm_result: ClaimRewardsResultType<Self::Api> = self
+            .staking_farm_proxy_obj(staking_farm_address)
+            .claim_rewards_with_new_value(new_staking_farm_values)
+            .with_multi_token_transfer(staking_farm_tokens)
+            .execute_on_dest_context_custom_range(|_, after| (after - 2, after));
+        let (new_staking_farm_tokens, staking_farm_rewards) = staking_farm_result.into_tuple();
+
+        StakingFarmClaimRewardsResult {
+            new_staking_farm_tokens,
+            staking_farm_rewards,
+        }
+    }
+
+    fn staking_farm_unstake(
+        &self,
+        staking_tokens: EsdtTokenPayment<Self::Api>,
+        farm_token_nonce: u64,
+        farm_token_amount: BigUint,
+    ) -> StakingFarmExitResult<Self::Api> {
+        let staking_farm_token_id = self.staking_farm_token_id().get();
+        let mut payments = ManagedVec::from_single_item(staking_tokens);
+        payments.push(EsdtTokenPayment::new(
+            staking_farm_token_id,
+            farm_token_nonce,
+            farm_token_amount,
+        ));
+
+        let staking_farm_address = self.staking_farm_address().get();
+        let unstake_result: ExitFarmResultType<Self::Api> = self
+            .staking_farm_proxy_obj(staking_farm_address)
+            .unstake_farm_through_proxy()
+            .with_multi_token_transfer(payments)
+            .execute_on_dest_context_custom_range(|_, after| (after - 2, after));
+        let (unbond_staking_farm_token, staking_rewards) = unstake_result.into_tuple();
+
+        StakingFarmExitResult {
+            unbond_staking_farm_token,
+            staking_rewards,
+        }
+    }
+
+    // pair
+
+    fn pair_remove_liquidity(
+        &self,
+        lp_tokens: EsdtTokenPayment<Self::Api>,
+        pair_first_token_min_amount: BigUint,
+        pair_second_token_min_amount: BigUint,
+    ) -> PairRemoveLiquidityResult<Self::Api> {
+        let pair_address = self.pair_address().get();
+        let pair_withdraw_result: RemoveLiquidityResultType<Self::Api> = self
+            .pair_proxy_obj(pair_address)
+            .remove_liquidity(
+                lp_tokens.token_identifier,
+                lp_tokens.token_nonce,
+                lp_tokens.amount,
+                pair_first_token_min_amount,
+                pair_second_token_min_amount,
+                OptionalArg::None,
+            )
+            .execute_on_dest_context();
+        let (pair_first_token_payment, pair_second_token_payment) =
+            pair_withdraw_result.into_tuple();
+
+        let staking_token_id = self.staking_token_id().get();
+        let (staking_token_payment, other_token_payment) =
+            if pair_first_token_payment.token_identifier == staking_token_id {
+                (pair_first_token_payment, pair_second_token_payment)
+            } else if pair_second_token_payment.token_identifier == staking_token_id {
+                (pair_second_token_payment, pair_first_token_payment)
+            } else {
+                sc_panic!("Invalid payments received from Pair");
+            };
+
+        PairRemoveLiquidityResult {
+            staking_token_payment,
+            other_token_payment,
+        }
+    }
+
+    fn get_lp_tokens_safe_price(&self, lp_tokens_amount: BigUint) -> BigUint {
+        let pair_address = self.pair_address().get();
+        let result: SafePriceResult<Self::Api> = self
+            .pair_proxy_obj(pair_address)
+            .update_and_get_tokens_for_given_position_with_safe_price(lp_tokens_amount)
+            .execute_on_dest_context();
+        let (first_token_info, second_token_info) = result.into_tuple();
+        let staking_token_id = self.staking_token_id().get();
+
+        if first_token_info.token_identifier == staking_token_id {
+            first_token_info.amount
+        } else if second_token_info.token_identifier == staking_token_id {
+            second_token_info.amount
+        } else {
+            sc_panic!("Invalid Pair contract called");
+        }
+    }
+
+    // proxies
+
+    #[proxy]
+    fn staking_farm_proxy_obj(&self, sc_address: ManagedAddress) -> farm_staking::Proxy<Self::Api>;
+
+    #[proxy]
+    fn lp_farm_proxy_obj(&self, sc_address: ManagedAddress) -> farm::Proxy<Self::Api>;
+
+    #[proxy]
+    fn pair_proxy_obj(&self, sc_address: ManagedAddress) -> pair::Proxy<Self::Api>;
+
+    // storage
+
+    #[view(getLpFarmAddress)]
+    #[storage_mapper("lpFarmAddress")]
+    fn lp_farm_address(&self) -> SingleValueMapper<ManagedAddress>;
+
+    #[view(getStakingFarmAddress)]
+    #[storage_mapper("stakingFarmAddress")]
+    fn staking_farm_address(&self) -> SingleValueMapper<ManagedAddress>;
+
+    #[view(getPairAddress)]
+    #[storage_mapper("pairAddress")]
+    fn pair_address(&self) -> SingleValueMapper<ManagedAddress>;
+
+    #[view(getStakingTokenId)]
+    #[storage_mapper("stakingTokenId")]
+    fn staking_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
+
+    #[view(getFarmTokenId)]
+    #[storage_mapper("farmTokenId")]
+    fn staking_farm_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
+}

--- a/dex/farm-staking-proxy/src/lib.rs
+++ b/dex/farm-staking-proxy/src/lib.rs
@@ -2,17 +2,11 @@
 
 elrond_wasm::imports!();
 
-use farm::farm_token_merge::ProxyTrait as _;
-use pair::safe_price::ProxyTrait as _;
-
-use dual_yield_token::DualYieldTokenAttributes;
-use farm_staking::{ClaimRewardsResultType, EnterFarmResultType, ExitFarmResultType};
-use pair::RemoveLiquidityResultType;
-
 pub mod dual_yield_token;
+pub mod external_contracts_interactions;
 pub mod lp_farm_token;
+pub mod result_types;
 
-pub type SafePriceResult<Api> = MultiResult2<EsdtTokenPayment<Api>, EsdtTokenPayment<Api>>;
 pub type StakeResult<Api> = EsdtTokenPayment<Api>;
 pub type ClaimDualYieldResult<Api> = ManagedMultiResultVec<Api, EsdtTokenPayment<Api>>;
 pub type UnstakeResult<Api> = ManagedMultiResultVec<Api, EsdtTokenPayment<Api>>;
@@ -20,6 +14,7 @@ pub type UnstakeResult<Api> = ManagedMultiResultVec<Api, EsdtTokenPayment<Api>>;
 #[elrond_wasm::contract]
 pub trait FarmStakingProxy:
     dual_yield_token::DualYieldTokenModule
+    + external_contracts_interactions::ExternalContractsInteractionsModule
     + lp_farm_token::LpFarmTokenModule
     + token_merge::TokenMergeModule
 {
@@ -110,12 +105,9 @@ pub trait FarmStakingProxy:
             &merged_lp_farm_tokens.amount,
         );
         let staking_token_amount = self.get_lp_tokens_safe_price(lp_tokens_in_farm);
-        let staking_farm_address = self.staking_farm_address().get();
-        let received_staking_farm_token: EnterFarmResultType<Self::Api> = self
-            .staking_farm_proxy_obj(staking_farm_address)
-            .stake_farm_through_proxy(staking_token_amount)
-            .with_multi_token_transfer(staking_farm_tokens)
-            .execute_on_dest_context_custom_range(|_, after| (after - 1, after));
+        let received_staking_farm_token = self
+            .staking_farm_enter(staking_token_amount, staking_farm_tokens)
+            .received_staking_farm_token;
 
         let caller = self.blockchain().get_caller();
         self.create_and_send_dual_yield_tokens(
@@ -169,22 +161,12 @@ pub trait FarmStakingProxy:
             self.burn_dual_yield_tokens(p.token_nonce, &p.amount);
         }
 
-        let lp_farm_address = self.lp_farm_address().get();
-        let lp_farm_result: ClaimRewardsResultType<Self::Api> = self
-            .lp_farm_proxy_obj(lp_farm_address)
-            .claim_rewards(OptionalArg::None)
-            .with_multi_token_transfer(lp_farm_tokens)
-            .execute_on_dest_context_custom_range(|_, after| (after - 2, after));
-        let (new_lp_farm_tokens, lp_farm_rewards) = lp_farm_result.into_tuple();
+        let lp_farm_claim_rewards_result = self.lp_farm_claim_rewards(lp_farm_tokens);
+        let staking_farm_claim_rewards_result =
+            self.staking_farm_claim_rewards(new_staking_farm_values, staking_farm_tokens);
 
-        let staking_farm_address = self.staking_farm_address().get();
-        let staking_farm_result: ClaimRewardsResultType<Self::Api> = self
-            .staking_farm_proxy_obj(staking_farm_address)
-            .claim_rewards_with_new_value(new_staking_farm_values)
-            .with_multi_token_transfer(staking_farm_tokens)
-            .execute_on_dest_context_custom_range(|_, after| (after - 2, after));
-        let (new_staking_farm_tokens, staking_farm_rewards) = staking_farm_result.into_tuple();
-
+        let new_lp_farm_tokens = lp_farm_claim_rewards_result.new_lp_farm_tokens;
+        let new_staking_farm_tokens = staking_farm_claim_rewards_result.new_staking_farm_tokens;
         let new_dual_yield_tokens = self.create_dual_yield_tokens(
             new_lp_farm_tokens.token_nonce,
             new_lp_farm_tokens.amount,
@@ -192,6 +174,19 @@ pub trait FarmStakingProxy:
             new_staking_farm_tokens.amount,
         );
 
+        self.send_claim_payments(
+            lp_farm_claim_rewards_result.lp_farm_rewards,
+            staking_farm_claim_rewards_result.staking_farm_rewards,
+            new_dual_yield_tokens,
+        )
+    }
+
+    fn send_claim_payments(
+        &self,
+        lp_farm_rewards: EsdtTokenPayment<Self::Api>,
+        staking_farm_rewards: EsdtTokenPayment<Self::Api>,
+        new_dual_yield_tokens: EsdtTokenPayment<Self::Api>,
+    ) -> ClaimDualYieldResult<Self::Api> {
         let mut user_output_payments = ManagedVec::new();
         if lp_farm_rewards.amount > 0 {
             user_output_payments.push(lp_farm_rewards);
@@ -226,20 +221,29 @@ pub trait FarmStakingProxy:
         self.require_dual_yield_token(&payment_token);
 
         let attributes = self.get_dual_yield_token_attributes(payment_nonce);
+        let lp_farm_token_amount =
+            self.get_lp_farm_token_amount_equivalent(&attributes, &payment_amount);
+        let lp_farm_exit_result =
+            self.lp_farm_exit(attributes.lp_farm_token_nonce, lp_farm_token_amount);
 
-        let (lp_tokens, lp_farm_rewards) = self.exit_farm(&payment_amount, &attributes);
-
-        let (staking_token_payment, other_token_payment) = self.remove_liquidity(
-            lp_tokens,
+        let remove_liq_result = self.pair_remove_liquidity(
+            lp_farm_exit_result.lp_tokens,
             pair_first_token_min_amount,
             pair_second_token_min_amount,
         );
-        let unstake_result = self.unstake(
-            &payment_amount,
-            &attributes,
-            lp_farm_rewards,
-            staking_token_payment,
-            other_token_payment,
+
+        let staking_farm_token_amount =
+            self.get_staking_farm_token_amount_equivalent(&payment_amount);
+        let staking_farm_exit_result = self.staking_farm_unstake(
+            remove_liq_result.staking_token_payment,
+            attributes.staking_farm_token_nonce,
+            staking_farm_token_amount,
+        );
+        let unstake_result = self.send_unstake_payments(
+            remove_liq_result.other_token_payment,
+            lp_farm_exit_result.lp_farm_rewards,
+            staking_farm_exit_result.staking_rewards,
+            staking_farm_exit_result.unbond_staking_farm_token,
         );
 
         self.burn_dual_yield_tokens(payment_nonce, &payment_amount);
@@ -247,89 +251,13 @@ pub trait FarmStakingProxy:
         unstake_result
     }
 
-    fn exit_farm(
+    fn send_unstake_payments(
         &self,
-        payment_amount: &BigUint,
-        attributes: &DualYieldTokenAttributes<Self::Api>,
-    ) -> (EsdtTokenPayment<Self::Api>, EsdtTokenPayment<Self::Api>) {
-        let lp_farm_token_id = self.lp_farm_token_id().get();
-        let lp_farm_token_amount =
-            self.get_lp_farm_token_amount_equivalent(attributes, payment_amount);
-        let lp_farm_address = self.lp_farm_address().get();
-        let exit_farm_result: ExitFarmResultType<Self::Api> = self
-            .lp_farm_proxy_obj(lp_farm_address)
-            .exit_farm(OptionalArg::None)
-            .add_token_transfer(
-                lp_farm_token_id,
-                attributes.lp_farm_token_nonce,
-                lp_farm_token_amount,
-            )
-            .execute_on_dest_context();
-
-        exit_farm_result.into_tuple()
-    }
-
-    fn remove_liquidity(
-        &self,
-        lp_tokens: EsdtTokenPayment<Self::Api>,
-        pair_first_token_min_amount: BigUint,
-        pair_second_token_min_amount: BigUint,
-    ) -> (EsdtTokenPayment<Self::Api>, EsdtTokenPayment<Self::Api>) {
-        let pair_address = self.pair_address().get();
-        let pair_withdraw_result: RemoveLiquidityResultType<Self::Api> = self
-            .pair_proxy_obj(pair_address)
-            .remove_liquidity(
-                lp_tokens.token_identifier,
-                lp_tokens.token_nonce,
-                lp_tokens.amount,
-                pair_first_token_min_amount,
-                pair_second_token_min_amount,
-                OptionalArg::None,
-            )
-            .execute_on_dest_context();
-        let (pair_first_token_payment, pair_second_token_payment) =
-            pair_withdraw_result.into_tuple();
-
-        let staking_token_id = self.staking_token_id().get();
-        let (staking_token_payment, other_token_payment) =
-            if pair_first_token_payment.token_identifier == staking_token_id {
-                (pair_first_token_payment, pair_second_token_payment)
-            } else if pair_second_token_payment.token_identifier == staking_token_id {
-                (pair_second_token_payment, pair_first_token_payment)
-            } else {
-                sc_panic!("Invalid payments received from Pair");
-            };
-
-        (staking_token_payment, other_token_payment)
-    }
-
-    fn unstake(
-        &self,
-        payment_amount: &BigUint,
-        attributes: &DualYieldTokenAttributes<Self::Api>,
-        lp_farm_rewards: EsdtTokenPayment<Self::Api>,
-        staking_token_payment: EsdtTokenPayment<Self::Api>,
         other_token_payment: EsdtTokenPayment<Self::Api>,
+        lp_farm_rewards: EsdtTokenPayment<Self::Api>,
+        staking_rewards: EsdtTokenPayment<Self::Api>,
+        unbond_staking_farm_token: EsdtTokenPayment<Self::Api>,
     ) -> UnstakeResult<Self::Api> {
-        let staking_farm_token_id = self.staking_farm_token_id().get();
-        let staking_farm_token_amount =
-            self.get_staking_farm_token_amount_equivalent(payment_amount);
-        let mut staking_sc_payments = ManagedVec::new();
-        staking_sc_payments.push(staking_token_payment);
-        staking_sc_payments.push(EsdtTokenPayment::new(
-            staking_farm_token_id,
-            attributes.staking_farm_token_nonce,
-            staking_farm_token_amount,
-        ));
-
-        let staking_farm_address = self.staking_farm_address().get();
-        let unstake_result: ExitFarmResultType<Self::Api> = self
-            .staking_farm_proxy_obj(staking_farm_address)
-            .unstake_farm_through_proxy()
-            .with_multi_token_transfer(staking_sc_payments)
-            .execute_on_dest_context_custom_range(|_, after| (after - 2, after));
-        let (unbond_staking_farm_token, staking_rewards) = unstake_result.into_tuple();
-
         let caller = self.blockchain().get_caller();
         let mut user_payments = ManagedVec::new();
         if other_token_payment.amount > 0 {
@@ -353,73 +281,4 @@ pub trait FarmStakingProxy:
 
         user_payments.into()
     }
-
-    fn get_lp_tokens_safe_price(&self, lp_tokens_amount: BigUint) -> BigUint {
-        let pair_address = self.pair_address().get();
-        let result: SafePriceResult<Self::Api> = self
-            .pair_proxy_obj(pair_address)
-            .update_and_get_tokens_for_given_position_with_safe_price(lp_tokens_amount)
-            .execute_on_dest_context();
-        let (first_token_info, second_token_info) = result.into_tuple();
-        let staking_token_id = self.staking_token_id().get();
-
-        if first_token_info.token_identifier == staking_token_id {
-            first_token_info.amount
-        } else if second_token_info.token_identifier == staking_token_id {
-            second_token_info.amount
-        } else {
-            sc_panic!("Invalid Pair contract called");
-        }
-    }
-
-    fn merge_lp_farm_tokens(
-        &self,
-        base_lp_token: EsdtTokenPayment<Self::Api>,
-        mut additional_lp_tokens: ManagedVec<EsdtTokenPayment<Self::Api>>,
-    ) -> EsdtTokenPayment<Self::Api> {
-        if additional_lp_tokens.is_empty() {
-            return base_lp_token;
-        }
-
-        additional_lp_tokens.push(base_lp_token);
-
-        let lp_farm_address = self.lp_farm_address().get();
-        self.lp_farm_proxy_obj(lp_farm_address)
-            .merge_farm_tokens(OptionalArg::None)
-            .with_multi_token_transfer(additional_lp_tokens)
-            .execute_on_dest_context()
-    }
-
-    // proxies
-
-    #[proxy]
-    fn staking_farm_proxy_obj(&self, sc_address: ManagedAddress) -> farm_staking::Proxy<Self::Api>;
-
-    #[proxy]
-    fn lp_farm_proxy_obj(&self, sc_address: ManagedAddress) -> farm::Proxy<Self::Api>;
-
-    #[proxy]
-    fn pair_proxy_obj(&self, sc_address: ManagedAddress) -> pair::Proxy<Self::Api>;
-
-    // storage
-
-    #[view(getLpFarmAddress)]
-    #[storage_mapper("lpFarmAddress")]
-    fn lp_farm_address(&self) -> SingleValueMapper<ManagedAddress>;
-
-    #[view(getStakingFarmAddress)]
-    #[storage_mapper("stakingFarmAddress")]
-    fn staking_farm_address(&self) -> SingleValueMapper<ManagedAddress>;
-
-    #[view(getPairAddress)]
-    #[storage_mapper("pairAddress")]
-    fn pair_address(&self) -> SingleValueMapper<ManagedAddress>;
-
-    #[view(getStakingTokenId)]
-    #[storage_mapper("stakingTokenId")]
-    fn staking_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
-
-    #[view(getFarmTokenId)]
-    #[storage_mapper("farmTokenId")]
-    fn staking_farm_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
 }

--- a/dex/farm-staking-proxy/src/result_types.rs
+++ b/dex/farm-staking-proxy/src/result_types.rs
@@ -1,0 +1,38 @@
+elrond_wasm::imports!();
+
+pub type PaymentsVec<M> = ManagedVec<M, EsdtTokenPayment<M>>;
+
+// lp farm
+
+pub struct LpFarmClaimRewardsResult<M: ManagedTypeApi> {
+    pub new_lp_farm_tokens: EsdtTokenPayment<M>,
+    pub lp_farm_rewards: EsdtTokenPayment<M>,
+}
+
+pub struct LpFarmExitResult<M: ManagedTypeApi> {
+    pub lp_tokens: EsdtTokenPayment<M>,
+    pub lp_farm_rewards: EsdtTokenPayment<M>,
+}
+
+// staking farm
+
+pub struct StakingFarmEnterResult<M: ManagedTypeApi> {
+    pub received_staking_farm_token: EsdtTokenPayment<M>,
+}
+
+pub struct StakingFarmClaimRewardsResult<M: ManagedTypeApi> {
+    pub new_staking_farm_tokens: EsdtTokenPayment<M>,
+    pub staking_farm_rewards: EsdtTokenPayment<M>,
+}
+
+pub struct StakingFarmExitResult<M: ManagedTypeApi> {
+    pub unbond_staking_farm_token: EsdtTokenPayment<M>,
+    pub staking_rewards: EsdtTokenPayment<M>,
+}
+
+// pair
+
+pub struct PairRemoveLiquidityResult<M: ManagedTypeApi> {
+    pub staking_token_payment: EsdtTokenPayment<M>,
+    pub other_token_payment: EsdtTokenPayment<M>,
+}


### PR DESCRIPTION
Move external contract interactions to a separate file. This makes the endpoints much cleaner, as they don't have to handle the whole call logic themselves. 