### PR TITLE
Price discovery improvements

### DIFF
--- a/price-discovery/src/common_storage.rs
+++ b/price-discovery/src/common_storage.rs
@@ -31,9 +31,9 @@ pub trait CommonStorageModule {
     #[storage_mapper("extraRewardsFinalAmount")]
     fn extra_rewards_final_amount(&self) -> SingleValueMapper<BigUint>;
 
-    #[view(totalLpTokensReceived)]
-    #[storage_mapper("totalLpTokensReceived")]
-    fn total_lp_tokens_received(&self) -> SingleValueMapper<BigUint>;
+    #[view(getTotalClaimableLpTokens)]
+    #[storage_mapper("totalClaimableLpTokens")]
+    fn total_claimable_lp_tokens(&self) -> SingleValueMapper<BigUint>;
 
     #[storage_mapper("extraLpTokens")]
     fn extra_lp_tokens(&self) -> SingleValueMapper<BigUint>;

--- a/price-discovery/src/common_storage.rs
+++ b/price-discovery/src/common_storage.rs
@@ -12,6 +12,10 @@ pub trait CommonStorageModule {
     #[storage_mapper("acceptedTokenId")]
     fn accepted_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
 
+    #[view(getExtraRewardsTokenId)]
+    #[storage_mapper("extraRewardsTokenId")]
+    fn extra_rewards_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
+
     #[view(getLpTokenId)]
     #[storage_mapper("lpTokenId")]
     fn lp_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
@@ -24,12 +28,18 @@ pub trait CommonStorageModule {
     #[storage_mapper("acceptedTokenFinalAmount")]
     fn accepted_token_final_amount(&self) -> SingleValueMapper<BigUint>;
 
+    #[storage_mapper("extraRewardsFinalAmount")]
+    fn extra_rewards_final_amount(&self) -> SingleValueMapper<BigUint>;
+
     #[view(totalLpTokensReceived)]
     #[storage_mapper("totalLpTokensReceived")]
     fn total_lp_tokens_received(&self) -> SingleValueMapper<BigUint>;
 
     #[storage_mapper("extraLpTokens")]
     fn extra_lp_tokens(&self) -> SingleValueMapper<BigUint>;
+
+    #[storage_mapper("extraRewards")]
+    fn extra_rewards(&self) -> SingleValueMapper<BigUint>;
 
     #[view(getStartBlock)]
     #[storage_mapper("startBlock")]

--- a/price-discovery/src/common_storage.rs
+++ b/price-discovery/src/common_storage.rs
@@ -20,23 +20,9 @@ pub trait CommonStorageModule {
     #[storage_mapper("lpTokenId")]
     fn lp_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
 
-    #[view(getLaunchedTokenFinalAmount)]
-    #[storage_mapper("launchedTokenFinalAmount")]
-    fn launched_token_final_amount(&self) -> SingleValueMapper<BigUint>;
-
-    #[view(getAcceptedTokenFinalAmount)]
-    #[storage_mapper("acceptedTokenFinalAmount")]
-    fn accepted_token_final_amount(&self) -> SingleValueMapper<BigUint>;
-
-    #[storage_mapper("extraRewardsFinalAmount")]
-    fn extra_rewards_final_amount(&self) -> SingleValueMapper<BigUint>;
-
-    #[view(getTotalClaimableLpTokens)]
-    #[storage_mapper("totalClaimableLpTokens")]
-    fn total_claimable_lp_tokens(&self) -> SingleValueMapper<BigUint>;
-
-    #[storage_mapper("extraLpTokens")]
-    fn extra_lp_tokens(&self) -> SingleValueMapper<BigUint>;
+    #[view(getTotalLpTokensReceived)]
+    #[storage_mapper("totalLpTokensReceived")]
+    fn total_lp_tokens_received(&self) -> SingleValueMapper<BigUint>;
 
     #[storage_mapper("extraRewards")]
     fn extra_rewards(&self) -> SingleValueMapper<BigUint>;
@@ -48,7 +34,4 @@ pub trait CommonStorageModule {
     #[view(getEndBlock)]
     #[storage_mapper("endBlock")]
     fn end_block(&self) -> SingleValueMapper<u64>;
-
-    #[storage_mapper("accumulatedPenalty")]
-    fn accumulated_penalty(&self, redeem_token_nonce: u64) -> SingleValueMapper<BigUint>;
 }

--- a/price-discovery/src/create_pool.rs
+++ b/price-discovery/src/create_pool.rs
@@ -58,13 +58,13 @@ pub trait CreatePoolModule: crate::common_storage::CommonStorageModule {
             token_type: EsdtTokenType::Fungible,
             token_identifier: launched_token_id,
             token_nonce: 0,
-            amount: launched_token_balance.clone(),
+            amount: launched_token_balance,
         });
         payments.push(EsdtTokenPayment {
             token_type: EsdtTokenType::Fungible,
             token_identifier: accepted_token_id,
             token_nonce: 0,
-            amount: accepted_token_balance.clone(),
+            amount: accepted_token_balance,
         });
 
         let dex_sc_address = self.dex_sc_address().get();

--- a/price-discovery/src/create_pool.rs
+++ b/price-discovery/src/create_pool.rs
@@ -99,7 +99,7 @@ pub trait CreatePoolModule: crate::common_storage::CommonStorageModule {
 
         self.lp_token_id().set(&lp_token.token_identifier);
         self.extra_lp_tokens().set(&extra_lp_tokens);
-        self.total_lp_tokens_received()
+        self.total_claimable_lp_tokens()
             .set(&(lp_token.amount - extra_lp_tokens));
 
         let current_epoch = self.blockchain().get_block_epoch();

--- a/price-discovery/src/create_pool.rs
+++ b/price-discovery/src/create_pool.rs
@@ -41,9 +41,11 @@ pub trait CreatePoolModule: crate::common_storage::CommonStorageModule {
 
         let launched_token_id = self.launched_token_id().get();
         let accepted_token_id = self.accepted_token_id().get();
+        let extra_rewards_token_id = self.extra_rewards_token_id().get();
 
         let launched_token_balance = self.blockchain().get_sc_balance(&launched_token_id, 0);
         let accepted_token_balance = self.blockchain().get_sc_balance(&accepted_token_id, 0);
+        let extra_rewards_balance = self.blockchain().get_sc_balance(&extra_rewards_token_id, 0);
         let launched_token_accumulated_penalty =
             self.accumulated_penalty(LAUNCHED_TOKEN_REDEEM_NONCE).get();
         let accepted_token_accumulated_penalty =
@@ -59,10 +61,13 @@ pub trait CreatePoolModule: crate::common_storage::CommonStorageModule {
             &launched_token_balance - &launched_token_accumulated_penalty;
         let accepted_token_final_amount =
             &accepted_token_balance - &accepted_token_accumulated_penalty;
+        let extra_rewards_final_amount = extra_rewards_balance;
         self.launched_token_final_amount()
             .set(&launched_token_final_amount);
         self.accepted_token_final_amount()
             .set(&accepted_token_final_amount);
+        self.extra_rewards_final_amount()
+            .set(&extra_rewards_final_amount);
 
         let mut payments = ManagedVec::<Self::Api, EsdtTokenPayment<Self::Api>>::new();
         payments.push(EsdtTokenPayment {

--- a/price-discovery/src/lib.rs
+++ b/price-discovery/src/lib.rs
@@ -226,7 +226,7 @@ pub trait PriceDiscovery:
         require!(payment_token == redeem_token_id, INVALID_PAYMENT_ERR_MSG);
 
         let rewards = self.compute_rewards(payment_nonce, &payment_amount);
-        self.burn_redeem_token_without_supply_decrease(payment_nonce, &payment_amount);
+        self.burn_redeem_token(payment_nonce, &payment_amount);
 
         let caller = self.blockchain().get_caller();
         if rewards.lp_tokens_amount > 0 {

--- a/price-discovery/src/lib.rs
+++ b/price-discovery/src/lib.rs
@@ -262,10 +262,9 @@ pub trait PriceDiscovery:
         }
 
         require!(launched_token_balance > 0, "No launched tokens available");
-        require!(
-            accepted_token_balance * MIN_PRICE_PRECISION / launched_token_balance >= min_price,
-            "Launched token below min price"
-        );
+
+        let current_price = accepted_token_balance * MIN_PRICE_PRECISION / launched_token_balance;
+        require!(current_price >= min_price, "Launched token below min price");
     }
 
     #[view(getMinLaunchedTokenPrice)]

--- a/price-discovery/src/phase.rs
+++ b/price-discovery/src/phase.rs
@@ -92,6 +92,13 @@ pub trait PhaseModule: crate::common_storage::CommonStorageModule {
         };
     }
 
+    fn require_deposit_extra_rewards_allowed(&self, phase: &Phase<Self::Api>) {
+        require!(
+            phase != &Phase::Unbond,
+            "Deposit extra rewards not allowed in this phase"
+        );
+    }
+
     #[storage_mapper("noLimitPhaseDurationBocks")]
     fn no_limit_phase_duration_blocks(&self) -> SingleValueMapper<u64>;
 

--- a/price-discovery/src/redeem_token.rs
+++ b/price-discovery/src/redeem_token.rs
@@ -112,15 +112,11 @@ pub trait RedeemTokenModule {
     }
 
     fn burn_redeem_token(&self, nonce: u64, amount: &BigUint) {
-        self.burn_redeem_token_without_supply_decrease(nonce, amount);
+        let redeem_token_id = self.redeem_token_id().get();
+        self.send().esdt_local_burn(&redeem_token_id, nonce, amount);
 
         self.redeem_token_total_circulating_supply(nonce)
             .update(|supply| *supply -= amount);
-    }
-
-    fn burn_redeem_token_without_supply_decrease(&self, nonce: u64, amount: &BigUint) {
-        let redeem_token_id = self.redeem_token_id().get();
-        self.send().esdt_local_burn(&redeem_token_id, nonce, amount);
     }
 
     #[proxy]

--- a/price-discovery/src/redeem_token.rs
+++ b/price-discovery/src/redeem_token.rs
@@ -112,11 +112,15 @@ pub trait RedeemTokenModule {
     }
 
     fn burn_redeem_token(&self, nonce: u64, amount: &BigUint) {
-        let redeem_token_id = self.redeem_token_id().get();
-        self.send().esdt_local_burn(&redeem_token_id, nonce, amount);
+        self.burn_redeem_token_without_supply_decrease(nonce, amount);
 
         self.redeem_token_total_circulating_supply(nonce)
             .update(|supply| *supply -= amount);
+    }
+
+    fn burn_redeem_token_without_supply_decrease(&self, nonce: u64, amount: &BigUint) {
+        let redeem_token_id = self.redeem_token_id().get();
+        self.send().esdt_local_burn(&redeem_token_id, nonce, amount);
     }
 
     #[proxy]

--- a/price-discovery/src/redeem_token.rs
+++ b/price-discovery/src/redeem_token.rs
@@ -1,8 +1,6 @@
 elrond_wasm::imports!();
 use hex_literal::hex;
 
-use crate::common_storage::MAX_PERCENTAGE;
-
 pub const LAUNCHED_TOKEN_REDEEM_NONCE: u64 = 1;
 pub const ACCEPTED_TOKEN_REDEEM_NONCE: u64 = 2;
 
@@ -114,16 +112,15 @@ pub trait RedeemTokenModule {
     }
 
     fn burn_redeem_token(&self, nonce: u64, amount: &BigUint) {
-        let redeem_token_id = self.redeem_token_id().get();
-        self.send().esdt_local_burn(&redeem_token_id, nonce, amount);
+        self.burn_redeem_token_without_supply_decrease(nonce, amount);
 
         self.redeem_token_total_circulating_supply(nonce)
             .update(|supply| *supply -= amount);
     }
 
-    fn get_percentage_of_total_supply(&self, nonce: u64, amount: &BigUint) -> BigUint {
-        let total_supply = self.redeem_token_total_circulating_supply(nonce).get();
-        amount * MAX_PERCENTAGE / total_supply
+    fn burn_redeem_token_without_supply_decrease(&self, nonce: u64, amount: &BigUint) {
+        let redeem_token_id = self.redeem_token_id().get();
+        self.send().esdt_local_burn(&redeem_token_id, nonce, amount);
     }
 
     #[proxy]

--- a/price-discovery/tests/price_disc_tests.rs
+++ b/price-discovery/tests/price_disc_tests.rs
@@ -350,15 +350,7 @@ fn create_pool_ok() {
         .execute_query(&pd_setup.pd_wrapper, |sc| {
             assert_eq!(sc.lp_token_id().get(), managed_token_id!(LP_TOKEN_ID));
             assert_eq!(
-                sc.launched_token_final_amount().get(),
-                managed_biguint!(5_000_000_000)
-            );
-            assert_eq!(
-                sc.accepted_token_final_amount().get(),
-                managed_biguint!(1_100_000_000)
-            );
-            assert_eq!(
-                sc.total_claimable_lp_tokens().get(),
+                sc.total_lp_tokens_received().get(),
                 managed_biguint!(expected_lp_token_balance)
             );
         })
@@ -550,21 +542,6 @@ pub fn redeem_with_extra_tokens_from_penalties_steps<PriceDiscObjBuilder, DexObj
 
     pd_setup.blockchain_wrapper.set_block_epoch(12);
 
-    let accumulated_penalty_amount = 100_000_000u64;
-    pd_setup
-        .blockchain_wrapper
-        .execute_query(&pd_setup.pd_wrapper, |sc| {
-            let accepted_token_penalty = sc.accumulated_penalty(ACCEPTED_TOKEN_REDEEM_NONCE).get();
-            let launched_token_penalty = sc.accumulated_penalty(LAUNCHED_TOKEN_REDEEM_NONCE).get();
-
-            assert_eq!(
-                accepted_token_penalty,
-                managed_biguint!(accumulated_penalty_amount)
-            );
-            assert_eq!(launched_token_penalty, managed_biguint!(0));
-        })
-        .assert_ok();
-
     let first_user_address = pd_setup.first_user_address.clone();
     let first_user_redeem_token_amount = rust_biguint!(600_000_000);
     call_redeem(
@@ -611,7 +588,7 @@ pub fn redeem_with_extra_tokens_from_penalties_steps<PriceDiscObjBuilder, DexObj
         first_user_expected_lp_tokens_balance
     );
 
-    let second_user_expected_lp_tokens_balance = rust_biguint!(272_727_044);
+    let second_user_expected_lp_tokens_balance = rust_biguint!(272_727_045);
     pd_setup.blockchain_wrapper.check_esdt_balance(
         &second_user_address,
         LP_TOKEN_ID,
@@ -640,13 +617,6 @@ pub fn redeem_with_extra_tokens_from_penalties_steps<PriceDiscObjBuilder, DexObj
         &dust,
     );
     println!("Dust LP tokens: {}", dust);
-
-    /*
-        First user LP tokens: 327272454
-        Second user LP tokens: 272727044
-        Owner LP tokens: 599999500
-        Dust LP tokens: 2
-    */
 }
 
 #[test]

--- a/price-discovery/tests/price_disc_tests.rs
+++ b/price-discovery/tests/price_disc_tests.rs
@@ -301,7 +301,7 @@ fn withdraw_too_late() {
     let mut pd_setup = init(price_discovery::contract_obj, pair_mock::contract_obj);
     user_deposit_ok_steps(&mut pd_setup);
 
-    pd_setup.blockchain_wrapper.set_block_nonce(END_BLOCK - 1);
+    pd_setup.blockchain_wrapper.set_block_nonce(END_BLOCK + 1);
 
     let caller_addr = pd_setup.first_user_address.clone();
     call_withdraw(&mut pd_setup, &caller_addr, &rust_biguint!(1_000))

--- a/price-discovery/tests/tests_common.rs
+++ b/price-discovery/tests/tests_common.rs
@@ -21,10 +21,13 @@ pub const EXTRA_REWARDS_TOKEN_ID: &[u8] = b"EGLD";
 pub const OWNER_EGLD_BALANCE: u64 = 100_000_000;
 
 pub const START_BLOCK: u64 = 10;
-pub const END_BLOCK: u64 = 50;
 pub const NO_LIMIT_PHASE_DURATION_BLOCKS: u64 = 5;
 pub const LINEAR_PENALTY_PHASE_DURATION_BLOCKS: u64 = 5;
 pub const FIXED_PENALTY_PHASE_DURATION_BLOCKS: u64 = 5;
+pub const END_BLOCK: u64 = START_BLOCK
+    + NO_LIMIT_PHASE_DURATION_BLOCKS
+    + LINEAR_PENALTY_PHASE_DURATION_BLOCKS
+    + FIXED_PENALTY_PHASE_DURATION_BLOCKS;
 pub const UNBOND_EPOCHS: u64 = 7;
 
 pub const MIN_PENALTY_PERCENTAGE: u64 = 1_000_000_000_000; // 10%
@@ -147,7 +150,6 @@ where
                 managed_token_id!(EXTRA_REWARDS_TOKEN_ID),
                 managed_biguint!(0),
                 START_BLOCK,
-                END_BLOCK,
                 NO_LIMIT_PHASE_DURATION_BLOCKS,
                 LINEAR_PENALTY_PHASE_DURATION_BLOCKS,
                 FIXED_PENALTY_PHASE_DURATION_BLOCKS,

--- a/price-discovery/tests/tests_common.rs
+++ b/price-discovery/tests/tests_common.rs
@@ -17,6 +17,8 @@ pub const LAUNCHED_TOKEN_ID: &[u8] = b"SOCOOLWOW-123456";
 pub const ACCEPTED_TOKEN_ID: &[u8] = b"USDC-123456";
 pub const REDEEM_TOKEN_ID: &[u8] = b"GIBREWARDS-123456";
 pub const LP_TOKEN_ID: &[u8] = b"LPTOK-abcdef";
+pub const EXTRA_REWARDS_TOKEN_ID: &[u8] = b"EGLD";
+pub const MIN_PRICE: u64 = 0;
 
 pub const START_BLOCK: u64 = 10;
 pub const END_BLOCK: u64 = 50;
@@ -142,6 +144,8 @@ where
             sc.init(
                 managed_token_id!(LAUNCHED_TOKEN_ID),
                 managed_token_id!(ACCEPTED_TOKEN_ID),
+                managed_token_id!(EXTRA_REWARDS_TOKEN_ID),
+                managed_biguint!(MIN_PRICE),
                 START_BLOCK,
                 END_BLOCK,
                 NO_LIMIT_PHASE_DURATION_BLOCKS,

--- a/price-discovery/tests/tests_common.rs
+++ b/price-discovery/tests/tests_common.rs
@@ -18,7 +18,7 @@ pub const ACCEPTED_TOKEN_ID: &[u8] = b"USDC-123456";
 pub const REDEEM_TOKEN_ID: &[u8] = b"GIBREWARDS-123456";
 pub const LP_TOKEN_ID: &[u8] = b"LPTOK-abcdef";
 pub const EXTRA_REWARDS_TOKEN_ID: &[u8] = b"EGLD";
-pub const MIN_PRICE: u64 = 0;
+pub const OWNER_EGLD_BALANCE: u64 = 100_000_000;
 
 pub const START_BLOCK: u64 = 10;
 pub const END_BLOCK: u64 = 50;
@@ -55,7 +55,7 @@ where
 {
     let rust_zero = rust_biguint!(0u64);
     let mut blockchain_wrapper = BlockchainStateWrapper::new();
-    let owner_address = blockchain_wrapper.create_user_account(&rust_zero);
+    let owner_address = blockchain_wrapper.create_user_account(&rust_biguint!(OWNER_EGLD_BALANCE));
     let first_user_address = blockchain_wrapper.create_user_account(&rust_zero);
     let second_user_address = blockchain_wrapper.create_user_account(&rust_zero);
 
@@ -145,7 +145,7 @@ where
                 managed_token_id!(LAUNCHED_TOKEN_ID),
                 managed_token_id!(ACCEPTED_TOKEN_ID),
                 managed_token_id!(EXTRA_REWARDS_TOKEN_ID),
-                managed_biguint!(MIN_PRICE),
+                managed_biguint!(0),
                 START_BLOCK,
                 END_BLOCK,
                 NO_LIMIT_PHASE_DURATION_BLOCKS,
@@ -179,6 +179,25 @@ where
         pd_wrapper,
         dex_wrapper,
     }
+}
+
+pub fn call_deposit_extra_rewards<PriceDiscObjBuilder, DexObjBuilder>(
+    pd_setup: &mut PriceDiscSetup<PriceDiscObjBuilder, DexObjBuilder>,
+) where
+    PriceDiscObjBuilder: 'static + Copy + Fn() -> price_discovery::ContractObj<DebugApi>,
+    DexObjBuilder: 'static + Copy + Fn() -> pair_mock::ContractObj<DebugApi>,
+{
+    let b_wrapper = &mut pd_setup.blockchain_wrapper;
+    b_wrapper
+        .execute_tx(
+            &pd_setup.owner_address,
+            &pd_setup.pd_wrapper,
+            &rust_biguint!(OWNER_EGLD_BALANCE),
+            |sc| {
+                sc.deposit_extra_rewards();
+            },
+        )
+        .assert_ok();
 }
 
 pub fn call_deposit_initial_tokens<PriceDiscObjBuilder, DexObjBuilder>(

--- a/price-discovery/wasm/src/lib.rs
+++ b/price-discovery/wasm/src/lib.rs
@@ -10,14 +10,17 @@ elrond_wasm_node::wasm_endpoints! {
         callBack
         createDexLiquidityPool
         deposit
+        depositExtraRewards
         getAcceptedTokenFinalAmount
         getAcceptedTokenId
         getCurrentPhase
         getDexScAddress
         getEndBlock
+        getExtraRewardsTokenId
         getLaunchedTokenFinalAmount
         getLaunchedTokenId
         getLpTokenId
+        getMinLaunchedTokenPrice
         getRedeemTokenId
         getStartBlock
         issueRedeemToken

--- a/price-discovery/wasm/src/lib.rs
+++ b/price-discovery/wasm/src/lib.rs
@@ -23,10 +23,10 @@ elrond_wasm_node::wasm_endpoints! {
         getMinLaunchedTokenPrice
         getRedeemTokenId
         getStartBlock
+        getTotalClaimableLpTokens
         issueRedeemToken
         redeem
         setPairAddress
-        totalLpTokensReceived
         withdraw
     )
 }


### PR DESCRIPTION
- owner can now select a min-price for the launched token. The check is only activated after the initial launched tokens are deposited
- add an option for owner to add extra rewards. Users will receive their share based on the ratio of lp tokens the are entitled to.
- fix extra lp tokens calculation to also use the ratio of lp tokens from total