### PR TITLE
balance in storage

### DIFF
--- a/dex/price-discovery/src/common_storage.rs
+++ b/dex/price-discovery/src/common_storage.rs
@@ -20,13 +20,25 @@ pub trait CommonStorageModule {
     #[storage_mapper("lpTokenId")]
     fn lp_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
 
+    #[view(getLaunchedTokenBalance)]
+    #[storage_mapper("launchedTokenBalance")]
+    fn launched_token_balance(&self) -> SingleValueMapper<BigUint>;
+
+    #[view(getAcceptedTokenBalance)]
+    #[storage_mapper("acceptedTokenBalance")]
+    fn accepted_token_balance(&self) -> SingleValueMapper<BigUint>;
+
+    #[view(getExtraRewardsBalance)]
+    #[storage_mapper("extraRewardsBalance")]
+    fn extra_rewards_balance(&self) -> SingleValueMapper<BigUint>;
+
     #[view(getTotalLpTokensReceived)]
     #[storage_mapper("totalLpTokensReceived")]
     fn total_lp_tokens_received(&self) -> SingleValueMapper<BigUint>;
 
-    #[view(getExtraRewards)]
-    #[storage_mapper("extraRewards")]
-    fn extra_rewards(&self) -> SingleValueMapper<BigUint>;
+    #[view(getTotalExtraRewardsTokens)]
+    #[storage_mapper("totalExtraRewardsTokens")]
+    fn total_extra_rewards_tokens(&self) -> SingleValueMapper<BigUint>;
 
     #[view(getStartBlock)]
     #[storage_mapper("startBlock")]

--- a/dex/price-discovery/src/create_pool.rs
+++ b/dex/price-discovery/src/create_pool.rs
@@ -45,13 +45,15 @@ pub trait CreatePoolModule:
 
         let launched_token_id = self.launched_token_id().get();
         let accepted_token_id = self.accepted_token_id().get();
-        let extra_rewards_token_id = self.extra_rewards_token_id().get();
 
-        let launched_token_balance = self.blockchain().get_sc_balance(&launched_token_id, 0);
-        let accepted_token_balance = self.blockchain().get_sc_balance(&accepted_token_id, 0);
-        let extra_rewards_balance = self.blockchain().get_sc_balance(&extra_rewards_token_id, 0);
+        let launched_token_balance = self.launched_token_balance().get();
+        let accepted_token_balance = self.accepted_token_balance().get();
+        let extra_rewards_balance = self.extra_rewards_balance().get();
 
-        self.extra_rewards().set(&extra_rewards_balance);
+        self.launched_token_balance().clear();
+        self.accepted_token_balance().clear();
+        self.total_extra_rewards_tokens()
+            .set(&extra_rewards_balance);
 
         require!(
             launched_token_balance > 0,


### PR DESCRIPTION
Keep balance in storage instead of relying on get_sc_balance. This matters when reward token is the same as accepted token or launched token.