### PR TITLE
Use elrond-actions contracts.yml v1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,8 +9,8 @@ jobs:
     name: Contracts
     uses: ElrondNetwork/elrond-actions/.github/workflows/contracts.yml@v1
     with:
-      rust-toolchain: nightly-2021-11-04
-      vmtools-version: v1.4.32
+      rust-toolchain: nightly-2022-03-01
+      vmtools-version: v1.4.43
       extra-build-args: --ignore-eei-checks
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,109 +1,16 @@
-name: Builds and tests
+name: CI
 
 on:
   push:
   pull_request:
 
 jobs:
-  wasm_test:
-    name: Wasm tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          default: true
-          toolchain: nightly
-      - name: Install erdpy and vmtools
-        run : |
-          source .github/workflows/env
-          pip3 install erdpy
-          mkdir $HOME/elrondsdk
-          erdpy config set dependencies.vmtools.tag v1.4.32
-          erdpy deps install vmtools
-          erdpy config set dependencies.rust.tag nightly-2021-11-04
-          erdpy deps install rust
-          sudo apt install binaryen
-      - name: Build the wasm contracts
-        run: |
-          source .github/workflows/env
-          ./build-wasm.sh
-          ./wasm-opt.sh
-      - name: Run VM tests
-        run: |
-          source .github/workflows/env
-          cargo test --features elrond-wasm-debug/mandos-go-tests
-      - name: Generate file size report
-        run: |
-          source .github/workflows/env
-          ./sizes.sh > sizes.txt
-      - name: Upload file size report
-        uses: actions/upload-artifact@v2
-        with:
-          name: sizes
-          path: sizes.txt
-      - name: Download base report
-        uses: dawidd6/action-download-artifact@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        continue-on-error: true
-        with:
-          workflow: actions.yml
-          name: sizes
-          commit: ${{github.event.pull_request.base.sha}}
-          path: base-sizes
-      - name: Generate report
-        id: sizes-report
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          source .github/workflows/env
-          python tools/size-report/size_report.py base-sizes/sizes.txt sizes.txt --allow-missing > report.md
-      - name: Render report
-        id: template
-        uses: chuhlomin/render-template@v1.2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          template: report.md
-          vars: |
-            base: ${{github.event.pull_request.base.sha}}
-            head: ${{github.event.pull_request.head.sha}}
-      - name: Find sizes report comment
-        id: fc
-        uses: peter-evans/find-comment@v1
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Contract file size comparison
-      - name: Create or update sizes report comment
-        uses: peter-evans/create-or-update-comment@v1
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: ${{ steps.template.outputs.result }}
-          edit-mode: replace
-  rust_test:
-    name: Rust tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          default: true
-          toolchain: nightly
-      - name: Run rust tests
-        run: cargo test
-  clippy_check:
-    name: Clippy linter check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            components: clippy
-            default: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
+  contracts:
+    name: Contracts
+    uses: ElrondNetwork/elrond-actions/.github/workflows/contracts.yml@v1
+    with:
+      rust-toolchain: nightly-2021-11-04
+      vmtools-version: v1.4.32
+      extra-build-args: --ignore-eei-checks
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/env
+++ b/.github/workflows/env
@@ -1,1 +1,0 @@
-export PATH=$HOME/.local/bin:$HOME/elrondsdk/vmtools:$PATH


### PR DESCRIPTION
Use [`contracts.yml`](https://github.com/ElrondNetwork/elrond-actions/blob/v1/.github/workflows/contracts.yml). The rust version is the same as in the release workflow. The vmtools version was upgraded.
Side notes:
- `./build-wasm.sh` and `./wasm-opt.sh` are not used for github actions anymore since `erdpy contract build -r` is used now