### PR TITLE
Token attributes to nonce mapping

### DIFF
--- a/dex/price-discovery/tests/price_disc_tests.rs
+++ b/dex/price-discovery/tests/price_disc_tests.rs
@@ -384,7 +384,7 @@ fn redeem_ok() {
     pd_setup.blockchain_wrapper.check_nft_balance(
         &second_user_address,
         LOCKED_TOKEN_ID,
-        2,
+        1,
         &second_user_expected_launched_tokens_balance,
         &LockedTokenAttributes::<DebugApi> {
             original_token_id: managed_token_id!(LAUNCHED_TOKEN_ID),
@@ -398,7 +398,7 @@ fn redeem_ok() {
     pd_setup.blockchain_wrapper.check_nft_balance(
         &owner_address,
         LOCKED_TOKEN_ID,
-        3,
+        2,
         &owner_expected_accepted_tokens_balance,
         &LockedTokenAttributes::<DebugApi> {
             original_token_id: managed_token_id!(ACCEPTED_TOKEN_ID),

--- a/dex/tests/pair_rs_test.rs
+++ b/dex/tests/pair_rs_test.rs
@@ -1255,4 +1255,26 @@ fn add_liquidity_through_simple_lock_proxy() {
         MEX_TOKEN_ID,
         &(user_mex_balance_before + 500_000u32),
     );
+
+    // Add liquidity - same token pair as before -> same nonce (1)
+    pair_setup
+        .blockchain_wrapper
+        .execute_esdt_multi_transfer(
+            &pair_setup.user_address,
+            &locking_sc_wrapper,
+            &transfers[..],
+            |sc| {
+                let (_, _, lp_proxy_payment) = sc
+                    .add_liquidity_locked_token(managed_biguint!(1), managed_biguint!(1))
+                    .into_tuple();
+
+                assert_eq!(
+                    lp_proxy_payment.token_identifier,
+                    managed_token_id!(LP_PROXY_TOKEN_ID)
+                );
+                assert_eq!(lp_proxy_payment.token_nonce, 1);
+                assert_eq!(lp_proxy_payment.amount, managed_biguint!(500_000));
+            },
+        )
+        .assert_ok();
 }

--- a/locked-asset/simple-lock/src/lib.rs
+++ b/locked-asset/simple-lock/src/lib.rs
@@ -41,11 +41,8 @@ pub trait SimpleLock:
         let sft_nonce = self.get_or_create_nonce_for_attributes(&locked_token_mapper, &attributes);
 
         let dest_address = self.dest_from_optional(opt_destination);
-        let locked_tokens_payment =
-            self.locked_token()
-                .nft_add_quantity_and_send(&dest_address, sft_nonce, payment_amount);
-
-        locked_tokens_payment
+        self.locked_token()
+            .nft_add_quantity_and_send(&dest_address, sft_nonce, payment_amount)
     }
 
     #[payable("*")]

--- a/locked-asset/simple-lock/src/locked_token.rs
+++ b/locked-asset/simple-lock/src/locked_token.rs
@@ -1,7 +1,7 @@
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
-#[derive(TypeAbi, TopEncode, TopDecode, PartialEq, Debug)]
+#[derive(TypeAbi, TopEncode, TopDecode, NestedDecode, NestedEncode, PartialEq, Debug)]
 pub struct LockedTokenAttributes<M: ManagedTypeApi> {
     pub original_token_id: TokenIdentifier<M>,
     pub original_token_nonce: u64,

--- a/locked-asset/simple-lock/src/proxy_lp.rs
+++ b/locked-asset/simple-lock/src/proxy_lp.rs
@@ -160,7 +160,7 @@ pub trait ProxyLpModule:
         let lp_proxy_nonce = self
             .get_or_create_nonce_for_attributes(&lp_proxy_token_mapper, &proxy_token_attributes);
 
-        let lp_proxy_payment = self.lp_proxy_token().nft_add_quantity_and_send(
+        let lp_proxy_payment = lp_proxy_token_mapper.nft_add_quantity_and_send(
             &caller,
             lp_proxy_nonce,
             add_liq_result.lp_tokens.amount,

--- a/locked-asset/simple-lock/src/proxy_lp.rs
+++ b/locked-asset/simple-lock/src/proxy_lp.rs
@@ -22,6 +22,7 @@ pub type RemoveLiquidityThroughProxyResultType<M> =
 pub trait ProxyLpModule:
     crate::locked_token::LockedTokenModule
     + crate::lp_interactions::LpInteractionsModule
+    + crate::token_attributes::TokenAttributesModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     #[only_owner]
@@ -154,10 +155,15 @@ pub trait ProxyLpModule:
             first_payment_unlocked_wrapper,
             second_payment_unlocked_wrapper,
         );
-        let lp_proxy_payment = self.lp_proxy_token().nft_create_and_send(
+
+        let lp_proxy_token_mapper = self.lp_proxy_token();
+        let lp_proxy_nonce = self
+            .get_or_create_nonce_for_attributes(&lp_proxy_token_mapper, &proxy_token_attributes);
+
+        let lp_proxy_payment = self.lp_proxy_token().nft_add_quantity_and_send(
             &caller,
+            lp_proxy_nonce,
             add_liq_result.lp_tokens.amount,
-            &proxy_token_attributes,
         );
 
         (

--- a/locked-asset/simple-lock/src/token_attributes.rs
+++ b/locked-asset/simple-lock/src/token_attributes.rs
@@ -33,27 +33,6 @@ pub trait TokenAttributesModule {
         new_nonce
     }
 
-    fn get_attributes_for_nonce<T: TopDecode>(
-        &self,
-        token_id: &TokenIdentifier,
-        token_nonce: u64,
-    ) -> T {
-        let raw_attributes = self
-            .nonce_to_attributes_mapping(token_id, token_nonce)
-            .get();
-
-        T::top_decode(raw_attributes).unwrap_or_else(|err| sc_panic!(err.message_str()))
-    }
-
-    // TODO: Swap to TokenAttributes mapper from Rust framework on upgrade
-    // Current version is bugged, so we use a custom implementation for now
-    #[storage_mapper("nonceToAttributesMapping")]
-    fn nonce_to_attributes_mapping(
-        &self,
-        token_id: &TokenIdentifier,
-        token_nonce: u64,
-    ) -> SingleValueMapper<ManagedBuffer>;
-
     #[storage_mapper("attributesToNonceMapping")]
     fn attributes_to_nonce_mapping(
         &self,

--- a/locked-asset/simple-lock/src/token_attributes.rs
+++ b/locked-asset/simple-lock/src/token_attributes.rs
@@ -1,0 +1,63 @@
+elrond_wasm::imports!();
+elrond_wasm::derive_imports!();
+
+use elrond_codec::TopEncode;
+
+const INITIAL_SFT_AMOUNT: u32 = 1;
+
+#[elrond_wasm::module]
+pub trait TokenAttributesModule {
+    fn get_or_create_nonce_for_attributes<T: TopEncode + NestedEncode>(
+        &self,
+        nft_mapper: &NonFungibleTokenMapper<Self::Api>,
+        attributes: &T,
+    ) -> u64 {
+        let token_id = nft_mapper.get_token_id();
+        let mut encoded_attributes = ManagedBuffer::new();
+        attributes
+            .dep_encode(&mut encoded_attributes)
+            .unwrap_or_else(|err| sc_panic!(err.message_str()));
+
+        let attributes_to_nonce_mapper =
+            self.attributes_to_nonce_mapping(&token_id, &encoded_attributes);
+        let existing_nonce = attributes_to_nonce_mapper.get();
+        if existing_nonce != 0 {
+            return existing_nonce;
+        }
+
+        let new_nonce = nft_mapper
+            .nft_create(INITIAL_SFT_AMOUNT.into(), attributes)
+            .token_nonce;
+        attributes_to_nonce_mapper.set(&new_nonce);
+
+        new_nonce
+    }
+
+    fn get_attributes_for_nonce<T: TopDecode>(
+        &self,
+        token_id: &TokenIdentifier,
+        token_nonce: u64,
+    ) -> T {
+        let raw_attributes = self
+            .nonce_to_attributes_mapping(token_id, token_nonce)
+            .get();
+
+        T::top_decode(raw_attributes).unwrap_or_else(|err| sc_panic!(err.message_str()))
+    }
+
+    // TODO: Swap to TokenAttributes mapper from Rust framework on upgrade
+    // Current version is bugged, so we use a custom implementation for now
+    #[storage_mapper("nonceToAttributesMapping")]
+    fn nonce_to_attributes_mapping(
+        &self,
+        token_id: &TokenIdentifier,
+        token_nonce: u64,
+    ) -> SingleValueMapper<ManagedBuffer>;
+
+    #[storage_mapper("attributesToNonceMapping")]
+    fn attributes_to_nonce_mapping(
+        &self,
+        token_id: &TokenIdentifier,
+        attributes: &ManagedBuffer,
+    ) -> SingleValueMapper<u64>;
+}

--- a/locked-asset/simple-lock/tests/rust_test.rs
+++ b/locked-asset/simple-lock/tests/rust_test.rs
@@ -107,4 +107,34 @@ fn lock_unlock_test() {
         )
         .assert_ok();
     b_mock.check_esdt_balance(&user_addr, FREE_TOKEN_ID, &lock_amount);
+
+    // lock with same token, same unlock epoch -> same token nonce
+    b_mock
+        .execute_esdt_transfer(
+            &user_addr,
+            &sc_wrapper,
+            FREE_TOKEN_ID,
+            0,
+            &rust_biguint!(100),
+            |sc| {
+                let payment_result = sc.lock_tokens(10, OptionalValue::None);
+                assert_eq!(payment_result.token_nonce, lock_token_nonce);
+            },
+        )
+        .assert_ok();
+
+    // lock with same token, different unlock epoch -> different attributes -> different nonce
+    b_mock
+        .execute_esdt_transfer(
+            &user_addr,
+            &sc_wrapper,
+            FREE_TOKEN_ID,
+            0,
+            &rust_biguint!(100),
+            |sc| {
+                let payment_result = sc.lock_tokens(15, OptionalValue::None);
+                assert_eq!(payment_result.token_nonce, lock_token_nonce + 1);
+            },
+        )
+        .assert_ok();
 }


### PR DESCRIPTION
- (token_id, attributes) pairs are now mapped to specific token nonces, so tokens that have the exact same attributes no longer create different nonces for each locking/adding to lp