### PR TITLE
proxy farm merging

### DIFF
--- a/dex/tests/farm_rs_test.rs
+++ b/dex/tests/farm_rs_test.rs
@@ -861,20 +861,6 @@ fn test_farm_through_simple_lock() {
         &rust_biguint!(10 * PER_BLOCK_REWARD_AMOUNT),
     );
 
-    // user compound farm rewards - can only compound if farming token == reward token
-    b_mock
-        .execute_esdt_transfer(
-            &user_addr,
-            &lock_wrapper,
-            FARM_PROXY_TOKEN_ID,
-            2,
-            &rust_biguint!(1_000_000_000),
-            |sc| {
-                let _ = sc.farm_compound_rewards_locked_token();
-            },
-        )
-        .assert_user_error("Different token ids");
-
     // user exit farm
     b_mock.set_block_nonce(25);
 

--- a/locked-asset/simple-lock/src/proxy_farm.rs
+++ b/locked-asset/simple-lock/src/proxy_farm.rs
@@ -146,10 +146,14 @@ pub trait ProxyFarmModule:
         for p in &additional_proxy_farm_tokens {
             let proxy_farm_attributes: FarmProxyTokenAttributes<Self::Api> =
                 farm_proxy_token_mapper.get_token_attributes(p.token_nonce);
+
+            let same_farming_token =
+                proxy_farm_attributes.farming_token_id == lp_proxy_token_attributes.lp_token_id;
+            let same_farming_nonce =
+                proxy_farm_attributes.farming_token_locked_nonce == proxy_lp_payment.token_nonce;
+            let same_farm_type = proxy_farm_attributes.farm_type == farm_type;
             require!(
-                proxy_farm_attributes.farming_token_id == lp_proxy_token_attributes.lp_token_id
-                    && proxy_farm_attributes.farming_token_locked_nonce
-                        == proxy_lp_payment.token_nonce,
+                same_farming_token && same_farming_nonce && same_farm_type,
                 INVALID_PAYMENTS_ERR_MSG
             );
 


### PR DESCRIPTION
- `enterFarmLockedToken` now accepts additional `FarmProxyToken` payments, which are then unwrapped and sent to the farm for it to handle merging "automatically".