### PR TITLE
Metabonding staking snapshot pagination

### DIFF
--- a/farm-staking/metabonding-staking/src/locked_asset_token.rs
+++ b/farm-staking/metabonding-staking/src/locked_asset_token.rs
@@ -87,6 +87,11 @@ pub trait LockedAssetTokenModule {
             .execute_on_dest_context_custom_range(|_, after| (after - 1, after))
     }
 
+    #[inline]
+    fn get_user_entries_vec_mapper(&self) -> VecMapper<ManagedAddress> {
+        VecMapper::new(elrond_wasm::storage::StorageKey::new(b"userList"))
+    }
+
     // proxies
 
     #[proxy]

--- a/farm-staking/metabonding-staking/tests/metabonding_staking_setup/mod.rs
+++ b/farm-staking/metabonding-staking/tests/metabonding_staking_setup/mod.rs
@@ -198,6 +198,24 @@ where
         }
     }
 
+    pub fn call_stake_locked_asset_custom_caller(
+        &mut self,
+        caller: &Address,
+        token_nonce: u64,
+        amount: u64,
+    ) -> TxResult {
+        self.b_mock.execute_esdt_transfer(
+            caller,
+            &self.mbs_wrapper,
+            LOCKED_ASSET_TOKEN_ID,
+            token_nonce,
+            &rust_biguint!(amount),
+            |sc| {
+                sc.stake_locked_asset();
+            },
+        )
+    }
+
     pub fn call_stake_locked_asset(&mut self, token_nonce: u64, amount: u64) -> TxResult {
         self.b_mock.execute_esdt_transfer(
             &self.user_address,


### PR DESCRIPTION
- results are now returned in batches of 5K entries. Constant can be modified if 5K is still too much.