### PR TITLE
Farm contracts improvements

### DIFF
--- a/common/modules/farm/config/src/config.rs
+++ b/common/modules/farm/config/src/config.rs
@@ -93,10 +93,6 @@ pub trait ConfigModule: token_send::TokenSendModule {
     #[storage_mapper("last_reward_block_nonce")]
     fn last_reward_block_nonce(&self) -> SingleValueMapper<Nonce>;
 
-    #[view(getFarmTokenId)]
-    #[storage_mapper("farm_token_id")]
-    fn farm_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
-
     #[view(getDivisionSafetyConstant)]
     #[storage_mapper("division_safety_constant")]
     fn division_safety_constant(&self) -> SingleValueMapper<BigUint>;

--- a/common/modules/farm/config/src/config.rs
+++ b/common/modules/farm/config/src/config.rs
@@ -13,7 +13,7 @@ pub const DEFAULT_MINUMUM_FARMING_EPOCHS: u8 = 3;
 pub const DEFAULT_BURN_GAS_LIMIT: u64 = 50_000_000;
 pub const DEFAULT_NFT_DEPOSIT_MAX_LEN: usize = 10;
 
-#[derive(TopEncode, TopDecode, PartialEq, TypeAbi)]
+#[derive(TopEncode, TopDecode, PartialEq, TypeAbi, Clone, Copy)]
 pub enum State {
     Inactive,
     Active,

--- a/common/modules/farm/contexts/Cargo.toml
+++ b/common/modules/farm/contexts/Cargo.toml
@@ -30,3 +30,6 @@ path = "../config"
 
 [dependencies.elrond-wasm]
 version = "0.31.1"
+
+[dependencies.elrond-wasm-modules]
+version = "0.31.1"

--- a/common/modules/farm/contexts/src/ctx_helper.rs
+++ b/common/modules/farm/contexts/src/ctx_helper.rs
@@ -10,6 +10,7 @@ pub trait CtxHelper:
     + rewards::RewardsModule
     + farm_token::FarmTokenModule
     + token_merge::TokenMergeModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     fn new_farm_context(&self) -> GenericContext<Self::Api> {
         let caller = self.blockchain().get_caller();
@@ -37,7 +38,7 @@ pub trait CtxHelper:
 
     #[inline]
     fn load_farm_token_id(&self, context: &mut GenericContext<Self::Api>) {
-        context.set_farm_token_id(self.farm_token_id().get());
+        context.set_farm_token_id(self.farm_token().get_token_id());
     }
 
     #[inline]

--- a/common/modules/farm/contexts/src/generic.rs
+++ b/common/modules/farm/contexts/src/generic.rs
@@ -213,7 +213,7 @@ impl<M: ManagedTypeApi + BlockchainApi + StorageMapperApi + CallTypeApi + CallVa
     #[inline]
     pub fn get_input_attributes(&self) -> &FarmTokenAttributes<M> {
         if let Some(attr) = &self.tx_input.attributes {
-            return attr;
+            attr
         } else {
             M::error_api_impl().signal_error(b"No farm token attributes");
         }

--- a/common/modules/farm/contexts/src/generic.rs
+++ b/common/modules/farm/contexts/src/generic.rs
@@ -283,7 +283,7 @@ impl<M: ManagedTypeApi> GenericContext<M> {
 
     #[inline]
     pub fn set_output_position(&mut self, position: FarmToken<M>, created_with_merge: bool) {
-        self.output_payments.push(position.token_amount);
+        self.output_payments.push(position.payment);
         self.output_created_with_merge = created_with_merge;
         self.output_attributes = Some(position.attributes);
     }

--- a/common/modules/farm/contexts/src/generic.rs
+++ b/common/modules/farm/contexts/src/generic.rs
@@ -2,32 +2,41 @@ elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
 use common_structs::FarmTokenAttributes;
+use elrond_wasm::api::{CallTypeApi, StorageMapperApi};
 use farm_token::FarmToken;
 
 use config::State;
 
+pub trait FarmContracTraitBounds =
+    config::ConfigModule
+        + token_send::TokenSendModule
+        + rewards::RewardsModule
+        + farm_token::FarmTokenModule
+        + token_merge::TokenMergeModule
+        + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule;
+
 pub struct StorageCache<M: ManagedTypeApi> {
-    pub contract_state: Option<State>,
-    pub farm_token_id: Option<TokenIdentifier<M>>,
-    pub farming_token_id: Option<TokenIdentifier<M>>,
-    pub reward_token_id: Option<TokenIdentifier<M>>,
-    pub reward_reserve: Option<BigUint<M>>,
-    pub reward_per_share: Option<BigUint<M>>,
-    pub farm_token_supply: Option<BigUint<M>>,
-    pub division_safety_constant: Option<BigUint<M>>,
+    pub contract_state: State,
+    pub farm_token_id: TokenIdentifier<M>,
+    pub farming_token_id: TokenIdentifier<M>,
+    pub reward_token_id: TokenIdentifier<M>,
+    pub reward_reserve: BigUint<M>,
+    pub reward_per_share: BigUint<M>,
+    pub farm_token_supply: BigUint<M>,
+    pub division_safety_constant: BigUint<M>,
 }
 
-impl<M: ManagedTypeApi> Default for StorageCache<M> {
-    fn default() -> Self {
+impl<M: ManagedTypeApi + StorageMapperApi + CallTypeApi> StorageCache<M> {
+    fn new<C: FarmContracTraitBounds<Api = M>>(farm_sc: &C) -> Self {
         StorageCache {
-            contract_state: None,
-            farm_token_id: None,
-            farming_token_id: None,
-            reward_token_id: None,
-            reward_reserve: None,
-            reward_per_share: None,
-            farm_token_supply: None,
-            division_safety_constant: None,
+            contract_state: farm_sc.state().get(),
+            farm_token_id: farm_sc.farm_token().get_token_id(),
+            farming_token_id: farm_sc.farming_token_id().get(),
+            reward_token_id: farm_sc.reward_token_id().get(),
+            reward_reserve: farm_sc.reward_reserve().get(),
+            reward_per_share: farm_sc.reward_per_share().get(),
+            farm_token_supply: farm_sc.farm_token_supply().get(),
+            division_safety_constant: farm_sc.division_safety_constant().get(),
         }
     }
 }
@@ -47,45 +56,40 @@ pub struct GenericContext<M: ManagedTypeApi> {
 }
 
 pub struct GenericTxInput<M: ManagedTypeApi> {
-    payments: GenericPayments<M>,
-    attributes: Option<FarmTokenAttributes<M>>,
+    pub first_payment: EsdtTokenPayment<M>,
+    pub additional_payments: ManagedVec<M, EsdtTokenPayment<M>>,
+    pub attributes: FarmTokenAttributes<M>,
 }
 
-pub struct GenericPayments<M: ManagedTypeApi> {
-    first_payment: EsdtTokenPayment<M>,
-    additional_payments: ManagedVec<M, EsdtTokenPayment<M>>,
-}
+impl<M: ManagedTypeApi + StorageMapperApi + CallTypeApi + CallValueApi> GenericTxInput<M> {
+    pub fn new<C: FarmContracTraitBounds<Api = M>>(farm_sc: &C) -> Self {
+        let mut payments = farm_sc.call_value().all_esdt_transfers();
 
-impl<M: ManagedTypeApi> GenericTxInput<M> {
-    pub fn new(payments: GenericPayments<M>) -> Self {
+        let first_payment = payments.get(0);
+        payments.remove(0);
+
+        let attributes = farm_sc
+            .get_farm_token_attributes(&first_payment.token_identifier, first_payment.token_nonce);
+
         GenericTxInput {
-            payments,
-            attributes: None,
-        }
-    }
-}
-
-impl<M: ManagedTypeApi> GenericPayments<M> {
-    pub fn new(
-        first_payment: EsdtTokenPayment<M>,
-        additional_payments: ManagedVec<M, EsdtTokenPayment<M>>,
-    ) -> Self {
-        GenericPayments {
             first_payment,
-            additional_payments,
+            additional_payments: payments,
+            attributes,
         }
     }
 }
 
-impl<M: ManagedTypeApi> GenericContext<M> {
-    pub fn new(tx_input: GenericTxInput<M>, caller: ManagedAddress<M>) -> Self {
+impl<M: ManagedTypeApi + BlockchainApi + StorageMapperApi + CallTypeApi + CallValueApi>
+    GenericContext<M>
+{
+    pub fn new<'a, C: FarmContracTraitBounds<Api = M>>(farm_sc: &'a C) -> Self {
         GenericContext {
-            caller,
-            tx_input,
-            block_nonce: 0,
-            block_epoch: 0,
+            caller: farm_sc.blockchain().get_caller(),
+            block_epoch: farm_sc.blockchain().get_block_epoch(),
+            block_nonce: farm_sc.blockchain().get_block_nonce(),
+            tx_input: GenericTxInput::new(farm_sc),
+            storage_cache: StorageCache::new(farm_sc),
             position_reward: BigUint::zero(),
-            storage_cache: StorageCache::default(),
             initial_farming_amount: BigUint::zero(),
             final_reward: None,
             output_attributes: None,
@@ -93,17 +97,15 @@ impl<M: ManagedTypeApi> GenericContext<M> {
             output_payments: ManagedVec::new(),
         }
     }
-}
 
-impl<M: ManagedTypeApi> GenericContext<M> {
     #[inline]
     pub fn set_contract_state(&mut self, contract_state: State) {
-        self.storage_cache.contract_state = Some(contract_state);
+        self.storage_cache.contract_state = contract_state;
     }
 
     #[inline]
-    pub fn get_contract_state(&self) -> Option<&State> {
-        self.storage_cache.contract_state.as_ref()
+    pub fn get_contract_state(&self) -> State {
+        self.storage_cache.contract_state
     }
 
     #[inline]
@@ -127,48 +129,23 @@ impl<M: ManagedTypeApi> GenericContext<M> {
     }
 
     #[inline]
-    pub fn set_farm_token_id(&mut self, farm_token_id: TokenIdentifier<M>) {
-        self.storage_cache.farm_token_id = Some(farm_token_id)
+    pub fn get_farm_token_id(&self) -> &TokenIdentifier<M> {
+        &self.storage_cache.farm_token_id
     }
 
     #[inline]
-    pub fn get_farm_token_id(&self) -> Option<&TokenIdentifier<M>> {
-        self.storage_cache.farm_token_id.as_ref()
+    pub fn get_farming_token_id(&self) -> &TokenIdentifier<M> {
+        &self.storage_cache.farming_token_id
     }
 
     #[inline]
-    pub fn set_farming_token_id(&mut self, farming_token_id: TokenIdentifier<M>) {
-        self.storage_cache.farming_token_id = Some(farming_token_id)
-    }
-
-    #[inline]
-    pub fn get_farming_token_id(&self) -> Option<&TokenIdentifier<M>> {
-        self.storage_cache.farming_token_id.as_ref()
-    }
-
-    #[inline]
-    pub fn set_reward_token_id(&mut self, reward_token_id: TokenIdentifier<M>) {
-        self.storage_cache.reward_token_id = Some(reward_token_id);
-    }
-
-    #[inline]
-    pub fn get_reward_token_id(&self) -> Option<&TokenIdentifier<M>> {
-        self.storage_cache.reward_token_id.as_ref()
-    }
-
-    #[inline]
-    pub fn set_block_nonce(&mut self, nonce: u64) {
-        self.block_nonce = nonce;
+    pub fn get_reward_token_id(&self) -> &TokenIdentifier<M> {
+        &self.storage_cache.reward_token_id
     }
 
     #[inline]
     pub fn get_block_nonce(&self) -> u64 {
         self.block_nonce
-    }
-
-    #[inline]
-    pub fn set_block_epoch(&mut self, epoch: u64) {
-        self.block_epoch = epoch;
     }
 
     #[inline]
@@ -178,47 +155,42 @@ impl<M: ManagedTypeApi> GenericContext<M> {
 
     #[inline]
     pub fn set_reward_per_share(&mut self, rps: BigUint<M>) {
-        self.storage_cache.reward_per_share = Some(rps);
+        self.storage_cache.reward_per_share = rps;
     }
 
     #[inline]
-    pub fn get_reward_per_share(&self) -> Option<&BigUint<M>> {
-        self.storage_cache.reward_per_share.as_ref()
+    pub fn get_reward_per_share(&self) -> &BigUint<M> {
+        &self.storage_cache.reward_per_share
     }
 
     #[inline]
     pub fn set_farm_token_supply(&mut self, supply: BigUint<M>) {
-        self.storage_cache.farm_token_supply = Some(supply);
+        self.storage_cache.farm_token_supply = supply;
     }
 
     #[inline]
-    pub fn get_farm_token_supply(&self) -> Option<&BigUint<M>> {
-        self.storage_cache.farm_token_supply.as_ref()
+    pub fn get_farm_token_supply(&self) -> &BigUint<M> {
+        &self.storage_cache.farm_token_supply
     }
 
     #[inline]
-    pub fn set_division_safety_constant(&mut self, dsc: BigUint<M>) {
-        self.storage_cache.division_safety_constant = Some(dsc);
-    }
-
-    #[inline]
-    pub fn get_division_safety_constant(&self) -> Option<&BigUint<M>> {
-        self.storage_cache.division_safety_constant.as_ref()
+    pub fn get_division_safety_constant(&self) -> &BigUint<M> {
+        &self.storage_cache.division_safety_constant
     }
 
     #[inline]
     pub fn set_reward_reserve(&mut self, rr: BigUint<M>) {
-        self.storage_cache.reward_reserve = Some(rr);
+        self.storage_cache.reward_reserve = rr;
     }
 
     #[inline]
-    pub fn get_reward_reserve(&self) -> Option<&BigUint<M>> {
-        self.storage_cache.reward_reserve.as_ref()
+    pub fn get_reward_reserve(&self) -> &BigUint<M> {
+        &self.storage_cache.reward_reserve
     }
 
     #[inline]
     pub fn decrease_reward_reserve(&mut self) {
-        *self.storage_cache.reward_reserve.as_mut().unwrap() -= &self.position_reward;
+        self.storage_cache.reward_reserve -= &self.position_reward;
     }
 
     #[inline]
@@ -232,13 +204,8 @@ impl<M: ManagedTypeApi> GenericContext<M> {
     }
 
     #[inline]
-    pub fn set_input_attributes(&mut self, attr: FarmTokenAttributes<M>) {
-        self.tx_input.attributes = Some(attr);
-    }
-
-    #[inline]
-    pub fn get_input_attributes(&self) -> Option<&FarmTokenAttributes<M>> {
-        self.tx_input.attributes.as_ref()
+    pub fn get_input_attributes(&self) -> &FarmTokenAttributes<M> {
+        &self.tx_input.attributes
     }
 
     #[inline]
@@ -247,8 +214,8 @@ impl<M: ManagedTypeApi> GenericContext<M> {
     }
 
     #[inline]
-    pub fn get_position_reward(&self) -> Option<&BigUint<M>> {
-        Some(&self.position_reward)
+    pub fn get_position_reward(&self) -> &BigUint<M> {
+        &self.position_reward
     }
 
     #[inline]
@@ -257,8 +224,8 @@ impl<M: ManagedTypeApi> GenericContext<M> {
     }
 
     #[inline]
-    pub fn get_initial_farming_amount(&self) -> Option<&BigUint<M>> {
-        Some(&self.initial_farming_amount)
+    pub fn get_initial_farming_amount(&self) -> &BigUint<M> {
+        &self.initial_farming_amount
     }
 
     #[inline]
@@ -281,36 +248,32 @@ impl<M: ManagedTypeApi> GenericContext<M> {
         self.output_attributes.as_ref()
     }
 
-    #[inline]
     pub fn set_output_position(&mut self, position: FarmToken<M>, created_with_merge: bool) {
         self.output_payments.push(position.payment);
         self.output_created_with_merge = created_with_merge;
         self.output_attributes = Some(position.attributes);
     }
 
-    #[inline]
     pub fn set_final_reward_for_emit_compound_event(&mut self) {
         self.final_reward = Some(EsdtTokenPayment::new(
-            self.storage_cache.reward_token_id.clone().unwrap(),
+            self.storage_cache.reward_token_id.clone(),
             0,
             self.position_reward.clone(),
         ));
     }
 
-    #[inline]
     pub fn is_accepted_payment_enter(&self) -> bool {
-        let first_payment_pass = &self.tx_input.payments.first_payment.token_identifier
-            == self.storage_cache.farming_token_id.as_ref().unwrap()
-            && self.tx_input.payments.first_payment.token_nonce == 0
-            && self.tx_input.payments.first_payment.amount != 0u64;
+        let first_payment_pass = self.tx_input.first_payment.token_identifier
+            == self.storage_cache.farming_token_id
+            && self.tx_input.first_payment.token_nonce == 0
+            && self.tx_input.first_payment.amount != 0u64;
 
         if !first_payment_pass {
             return false;
         }
 
-        for payment in self.tx_input.payments.additional_payments.iter() {
-            let payment_pass = &payment.token_identifier
-                == self.storage_cache.farm_token_id.as_ref().unwrap()
+        for payment in self.tx_input.additional_payments.iter() {
+            let payment_pass = payment.token_identifier == self.storage_cache.farm_token_id
                 && payment.token_nonce != 0
                 && payment.amount != 0;
 
@@ -322,18 +285,17 @@ impl<M: ManagedTypeApi> GenericContext<M> {
         true
     }
 
-    #[inline]
     pub fn is_accepted_payment_exit(&self) -> bool {
-        let first_payment_pass = &self.tx_input.payments.first_payment.token_identifier
-            == self.storage_cache.farm_token_id.as_ref().unwrap()
-            && self.tx_input.payments.first_payment.token_nonce != 0
-            && self.tx_input.payments.first_payment.amount != 0u64;
+        let first_payment_pass = self.tx_input.first_payment.token_identifier
+            == self.storage_cache.farm_token_id
+            && self.tx_input.first_payment.token_nonce != 0
+            && self.tx_input.first_payment.amount != 0u64;
 
         if !first_payment_pass {
             return false;
         }
 
-        self.tx_input.payments.additional_payments.is_empty()
+        self.tx_input.additional_payments.is_empty()
     }
 
     #[inline]
@@ -347,18 +309,17 @@ impl<M: ManagedTypeApi> GenericContext<M> {
     }
 
     fn is_accepted_payment_claim_compound(&self) -> bool {
-        let first_payment_pass = &self.tx_input.payments.first_payment.token_identifier
-            == self.storage_cache.farm_token_id.as_ref().unwrap()
-            && self.tx_input.payments.first_payment.token_nonce != 0
-            && self.tx_input.payments.first_payment.amount != 0u64;
+        let first_payment_pass = self.tx_input.first_payment.token_identifier
+            == self.storage_cache.farm_token_id
+            && self.tx_input.first_payment.token_nonce != 0
+            && self.tx_input.first_payment.amount != 0u64;
 
         if !first_payment_pass {
             return false;
         }
 
-        for payment in self.tx_input.payments.additional_payments.iter() {
-            let payment_pass = &payment.token_identifier
-                == self.storage_cache.farm_token_id.as_ref().unwrap()
+        for payment in self.tx_input.additional_payments.iter() {
+            let payment_pass = payment.token_identifier == self.storage_cache.farm_token_id
                 && payment.token_nonce != 0
                 && payment.amount != 0;
 
@@ -378,24 +339,5 @@ impl<M: ManagedTypeApi> GenericContext<M> {
     #[inline]
     pub fn decrease_farming_token_amount(&mut self, amount: &BigUint<M>) {
         self.initial_farming_amount -= amount;
-    }
-}
-
-impl<M: ManagedTypeApi> GenericPayments<M> {
-    #[inline]
-    pub fn get_first(&self) -> &EsdtTokenPayment<M> {
-        &self.first_payment
-    }
-
-    #[inline]
-    pub fn get_additional(&self) -> Option<&ManagedVec<M, EsdtTokenPayment<M>>> {
-        Some(&self.additional_payments)
-    }
-}
-
-impl<M: ManagedTypeApi> GenericTxInput<M> {
-    #[inline]
-    pub fn get_payments(&self) -> &GenericPayments<M> {
-        &self.payments
     }
 }

--- a/common/modules/farm/contexts/src/generic.rs
+++ b/common/modules/farm/contexts/src/generic.rs
@@ -12,7 +12,6 @@ pub trait FarmContracTraitBounds =
         + token_send::TokenSendModule
         + rewards::RewardsModule
         + farm_token::FarmTokenModule
-        + token_merge::TokenMergeModule
         + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule;
 
 pub struct StorageCache<M: ManagedTypeApi> {
@@ -27,7 +26,7 @@ pub struct StorageCache<M: ManagedTypeApi> {
 }
 
 impl<M: ManagedTypeApi + StorageMapperApi + CallTypeApi> StorageCache<M> {
-    fn new<C: FarmContracTraitBounds<Api = M>>(farm_sc: &C) -> Self {
+    pub fn new<C: FarmContracTraitBounds<Api = M>>(farm_sc: &C) -> Self {
         StorageCache {
             contract_state: farm_sc.state().get(),
             farm_token_id: farm_sc.farm_token().get_token_id(),

--- a/common/modules/farm/contexts/src/mod.rs
+++ b/common/modules/farm/contexts/src/mod.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(trait_alias)]
 
 pub mod ctx_helper;
 pub mod generic;

--- a/common/modules/farm/farm_token/Cargo.toml
+++ b/common/modules/farm/farm_token/Cargo.toml
@@ -21,3 +21,6 @@ path = "../../token_send"
 
 [dependencies.elrond-wasm]
 version = "0.31.1"
+
+[dependencies.elrond-wasm-modules]
+version = "0.31.1"

--- a/common/modules/farm/migration_from_v1_2/Cargo.toml
+++ b/common/modules/farm/migration_from_v1_2/Cargo.toml
@@ -27,3 +27,6 @@ path = "../rewards"
 
 [dependencies.elrond-wasm]
 version = "0.31.1"
+
+[dependencies.elrond-wasm-modules]
+version = "0.31.1"

--- a/common/modules/farm/rewards/Cargo.toml
+++ b/common/modules/farm/rewards/Cargo.toml
@@ -24,3 +24,6 @@ path = "../../token_send"
 
 [dependencies.elrond-wasm]
 version = "0.31.1"
+
+[dependencies.elrond-wasm-modules]
+version = "0.31.1"

--- a/common/modules/farm/rewards/src/rewards.rs
+++ b/common/modules/farm/rewards/src/rewards.rs
@@ -7,7 +7,10 @@ use common_structs::Nonce;
 
 #[elrond_wasm::module]
 pub trait RewardsModule:
-    config::ConfigModule + farm_token::FarmTokenModule + token_send::TokenSendModule
+    config::ConfigModule
+    + farm_token::FarmTokenModule
+    + token_send::TokenSendModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     fn calculate_per_block_rewards(
         &self,

--- a/dex/Cargo.toml
+++ b/dex/Cargo.toml
@@ -16,6 +16,9 @@ num-bigint = "0.4.2"
 [dev-dependencies.config]
 path = "../common/modules/farm/config"
 
+[dev-dependencies.farm_token]
+path = "../common/modules/farm/farm_token"
+
 [dev-dependencies.rewards]
 path = "../common/modules/farm/rewards"
 

--- a/dex/farm/Cargo.toml
+++ b/dex/farm/Cargo.toml
@@ -47,5 +47,8 @@ path = "../../common/common_errors"
 [dependencies.elrond-wasm]
 version = "0.31.1"
 
+[dependencies.elrond-wasm-modules]
+version = "0.31.1"
+
 [dev-dependencies.elrond-wasm-debug]
 version = "0.31.1"

--- a/dex/farm/src/custom_rewards.rs
+++ b/dex/farm/src/custom_rewards.rs
@@ -11,6 +11,7 @@ pub trait CustomRewardsModule:
     + token_send::TokenSendModule
     + farm_token::FarmTokenModule
     + rewards::RewardsModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     fn mint_per_block_rewards(&self, token_id: &TokenIdentifier) -> BigUint {
         let current_block_nonce = self.blockchain().get_block_nonce();

--- a/dex/farm/src/custom_rewards.rs
+++ b/dex/farm/src/custom_rewards.rs
@@ -31,15 +31,15 @@ pub trait CustomRewardsModule:
     }
 
     fn generate_aggregated_rewards(&self, storage: &mut StorageCache<Self::Api>) {
-        let total_reward = self.mint_per_block_rewards(storage.reward_token_id.as_ref().unwrap());
+        let total_reward = self.mint_per_block_rewards(&storage.reward_token_id);
 
         if total_reward > 0u64 {
-            *storage.reward_reserve.as_mut().unwrap() += &total_reward;
+            storage.reward_reserve += &total_reward;
 
-            if storage.farm_token_supply.as_ref().unwrap() != &0u64 {
-                let increase = total_reward * storage.division_safety_constant.as_ref().unwrap()
-                    / storage.farm_token_supply.as_ref().unwrap();
-                *storage.reward_per_share.as_mut().unwrap() += &increase;
+            if storage.farm_token_supply != 0u64 {
+                let increase = (&total_reward * &storage.division_safety_constant)
+                    / &storage.farm_token_supply;
+                storage.reward_per_share += &increase;
             }
         }
     }
@@ -47,23 +47,13 @@ pub trait CustomRewardsModule:
     #[only_owner]
     #[endpoint]
     fn end_produce_rewards(&self) {
-        // TODO: duplicated code
-        let mut storage = StorageCache {
-            reward_token_id: Some(self.reward_token_id().get()),
-            division_safety_constant: Some(self.division_safety_constant().get()),
-            farm_token_supply: Some(self.farm_token_supply().get()),
-            reward_reserve: Some(self.reward_reserve().get()),
-            reward_per_share: Some(self.reward_per_share().get()),
-            ..Default::default()
-        };
+        let mut storage = StorageCache::new(self);
 
         self.generate_aggregated_rewards(&mut storage);
-        self.reward_per_share()
-            .set(storage.reward_per_share.as_ref().unwrap());
-        self.reward_reserve()
-            .set(storage.reward_reserve.as_ref().unwrap());
+        self.reward_per_share().set(&storage.reward_per_share);
+        self.reward_reserve().set(&storage.reward_reserve);
 
-        self.produce_rewards_enabled().set(&false);
+        self.produce_rewards_enabled().set(false);
     }
 
     #[only_owner]
@@ -71,21 +61,11 @@ pub trait CustomRewardsModule:
     fn set_per_block_rewards(&self, per_block_amount: BigUint) {
         require!(per_block_amount != 0u64, ERROR_ZERO_AMOUNT);
 
-        // TODO: duplicated code
-        let mut storage = StorageCache {
-            reward_token_id: Some(self.reward_token_id().get()),
-            division_safety_constant: Some(self.division_safety_constant().get()),
-            farm_token_supply: Some(self.farm_token_supply().get()),
-            reward_reserve: Some(self.reward_reserve().get()),
-            reward_per_share: Some(self.reward_per_share().get()),
-            ..Default::default()
-        };
+        let mut storage = StorageCache::new(self);
 
         self.generate_aggregated_rewards(&mut storage);
-        self.reward_per_share()
-            .set(storage.reward_per_share.as_ref().unwrap());
-        self.reward_reserve()
-            .set(storage.reward_reserve.as_ref().unwrap());
+        self.reward_per_share().set(&storage.reward_per_share);
+        self.reward_reserve().set(&storage.reward_reserve);
 
         self.per_block_reward_amount().set(&per_block_amount);
     }

--- a/dex/farm/src/farm_token_merge.rs
+++ b/dex/farm/src/farm_token_merge.rs
@@ -62,7 +62,7 @@ pub trait FarmTokenMergeModule:
             let attributes =
                 self.get_farm_token_attributes(&payment.token_identifier, payment.token_nonce);
             tokens.push(FarmToken {
-                payment: payment,
+                payment,
                 attributes,
             });
         }

--- a/dex/farm/src/lib.rs
+++ b/dex/farm/src/lib.rs
@@ -476,13 +476,11 @@ pub trait Farm:
         }
     }
 
-    #[inline]
     fn should_apply_penalty(&self, entering_epoch: Epoch) -> bool {
         entering_epoch + self.minimum_farming_epochs().get() as u64
             > self.blockchain().get_block_epoch()
     }
 
-    #[inline]
     fn get_penalty_amount(&self, amount: &BigUint) -> BigUint {
         amount * self.penalty_percent().get() / MAX_PERCENT
     }

--- a/dex/farm/src/lib.rs
+++ b/dex/farm/src/lib.rs
@@ -83,44 +83,25 @@ pub trait Farm:
     fn enter_farm(&self) -> EnterFarmResultType<Self::Api> {
         let mut context = self.new_farm_context();
 
-        self.load_state(&mut context);
         require!(
-            context.get_contract_state().unwrap() == &State::Active,
+            context.get_contract_state() == State::Active,
             ERROR_NOT_ACTIVE
         );
-
-        self.load_farm_token_id(&mut context);
-        require!(
-            !context.get_farm_token_id().unwrap().is_empty(),
-            ERROR_NO_FARM_TOKEN
-        );
-
-        self.load_farming_token_id(&mut context);
+        require!(!context.get_farm_token_id().is_empty(), ERROR_NO_FARM_TOKEN);
         require!(context.is_accepted_payment_enter(), ERROR_BAD_PAYMENTS);
 
-        self.load_reward_token_id(&mut context);
-        self.load_reward_reserve(&mut context);
-        self.load_block_nonce(&mut context);
-        self.load_block_epoch(&mut context);
-        self.load_reward_per_share(&mut context);
-        self.load_farm_token_supply(&mut context);
-        self.load_division_safety_constant(&mut context);
         self.generate_aggregated_rewards(context.get_storage_cache_mut());
 
-        let first_payment_amount = context
-            .get_tx_input()
-            .get_payments()
-            .get_first()
-            .amount
-            .clone();
+        let tx_input = context.get_tx_input();
+        let first_payment_amount = tx_input.first_payment.amount.clone();
 
         let virtual_position_token_amount = EsdtTokenPayment::new(
-            context.get_farm_token_id().unwrap().clone(),
+            context.get_farm_token_id().clone(),
             0,
             first_payment_amount.clone(),
         );
         let virtual_position_attributes = FarmTokenAttributes {
-            reward_per_share: context.get_reward_per_share().unwrap().clone(),
+            reward_per_share: context.get_reward_per_share().clone(),
             entering_epoch: context.get_block_epoch(),
             original_entering_epoch: context.get_block_epoch(),
             initial_farming_amount: first_payment_amount.clone(),
@@ -134,11 +115,7 @@ pub trait Farm:
 
         let (new_farm_token, created_with_merge) = self.create_farm_tokens_by_merging(
             &virtual_position,
-            context
-                .get_tx_input()
-                .get_payments()
-                .get_additional()
-                .unwrap(),
+            &tx_input.additional_payments,
             context.get_storage_cache(),
         );
         context.set_output_position(new_farm_token, created_with_merge);
@@ -155,29 +132,12 @@ pub trait Farm:
     fn exit_farm(&self) -> ExitFarmResultType<Self::Api> {
         let mut context = self.new_farm_context();
 
-        self.load_state(&mut context);
         require!(
-            context.get_contract_state().unwrap() == &State::Active,
+            context.get_contract_state() == State::Active,
             ERROR_NOT_ACTIVE
         );
-
-        self.load_farm_token_id(&mut context);
-        require!(
-            !context.get_farm_token_id().unwrap().is_empty(),
-            ERROR_NO_FARM_TOKEN
-        );
-
-        self.load_farming_token_id(&mut context);
+        require!(!context.get_farm_token_id().is_empty(), ERROR_NO_FARM_TOKEN);
         require!(context.is_accepted_payment_exit(), ERROR_BAD_PAYMENTS);
-
-        self.load_reward_token_id(&mut context);
-        self.load_reward_reserve(&mut context);
-        self.load_block_nonce(&mut context);
-        self.load_block_epoch(&mut context);
-        self.load_reward_per_share(&mut context);
-        self.load_farm_token_supply(&mut context);
-        self.load_division_safety_constant(&mut context);
-        self.load_farm_attributes(&mut context);
 
         self.generate_aggregated_rewards(context.get_storage_cache_mut());
         self.calculate_reward(&mut context);
@@ -202,29 +162,12 @@ pub trait Farm:
     fn claim_rewards(&self) -> ClaimRewardsResultType<Self::Api> {
         let mut context = self.new_farm_context();
 
-        self.load_state(&mut context);
         require!(
-            context.get_contract_state().unwrap() == &State::Active,
+            context.get_contract_state() == State::Active,
             ERROR_NOT_ACTIVE
         );
-
-        self.load_farm_token_id(&mut context);
-        require!(
-            !context.get_farm_token_id().unwrap().is_empty(),
-            ERROR_NO_FARM_TOKEN
-        );
-
-        self.load_farming_token_id(&mut context);
+        require!(!context.get_farm_token_id().is_empty(), ERROR_NO_FARM_TOKEN);
         require!(context.is_accepted_payment_claim(), ERROR_BAD_PAYMENTS);
-
-        self.load_reward_token_id(&mut context);
-        self.load_reward_reserve(&mut context);
-        self.load_block_nonce(&mut context);
-        self.load_block_epoch(&mut context);
-        self.load_reward_per_share(&mut context);
-        self.load_farm_token_supply(&mut context);
-        self.load_division_safety_constant(&mut context);
-        self.load_farm_attributes(&mut context);
 
         self.generate_aggregated_rewards(context.get_storage_cache_mut());
         self.calculate_reward(&mut context);
@@ -233,31 +176,19 @@ pub trait Farm:
         self.calculate_initial_farming_amount(&mut context);
         let new_compound_reward_amount = self.calculate_new_compound_reward_amount(&context);
 
+        let tx_input = context.get_tx_input();
         let virtual_position_token_amount = EsdtTokenPayment::new(
-            context.get_farm_token_id().unwrap().clone(),
+            context.get_farm_token_id().clone(),
             0,
-            context
-                .get_tx_input()
-                .get_payments()
-                .get_first()
-                .amount
-                .clone(),
+            tx_input.first_payment.amount.clone(),
         );
         let virtual_position_attributes = FarmTokenAttributes {
-            reward_per_share: context.get_reward_per_share().unwrap().clone(),
-            entering_epoch: context.get_input_attributes().unwrap().entering_epoch,
-            original_entering_epoch: context
-                .get_input_attributes()
-                .unwrap()
-                .original_entering_epoch,
-            initial_farming_amount: context.get_initial_farming_amount().unwrap().clone(),
+            reward_per_share: context.get_reward_per_share().clone(),
+            entering_epoch: context.get_input_attributes().entering_epoch,
+            original_entering_epoch: context.get_input_attributes().original_entering_epoch,
+            initial_farming_amount: context.get_initial_farming_amount().clone(),
             compounded_reward: new_compound_reward_amount,
-            current_farm_amount: context
-                .get_tx_input()
-                .get_payments()
-                .get_first()
-                .amount
-                .clone(),
+            current_farm_amount: tx_input.first_payment.amount.clone(),
         };
         let virtual_position = FarmToken {
             payment: virtual_position_token_amount,
@@ -266,11 +197,7 @@ pub trait Farm:
 
         let (new_farm_token, created_with_merge) = self.create_farm_tokens_by_merging(
             &virtual_position,
-            context
-                .get_tx_input()
-                .get_payments()
-                .get_additional()
-                .unwrap(),
+            &tx_input.additional_payments,
             context.get_storage_cache(),
         );
         context.set_output_position(new_farm_token, created_with_merge);
@@ -290,59 +217,40 @@ pub trait Farm:
     fn compound_rewards(&self) -> CompoundRewardsResultType<Self::Api> {
         let mut context = self.new_farm_context();
 
-        self.load_state(&mut context);
         require!(
-            context.get_contract_state().unwrap() == &State::Active,
+            context.get_contract_state() == State::Active,
             ERROR_NOT_ACTIVE
         );
-
-        self.load_farm_token_id(&mut context);
-        require!(
-            !context.get_farm_token_id().unwrap().is_empty(),
-            ERROR_NO_FARM_TOKEN
-        );
-
-        self.load_farming_token_id(&mut context);
-        self.load_reward_token_id(&mut context);
+        require!(!context.get_farm_token_id().is_empty(), ERROR_NO_FARM_TOKEN);
         require!(context.is_accepted_payment_compound(), ERROR_BAD_PAYMENTS);
-
         require!(
-            context.get_farming_token_id().unwrap() == context.get_reward_token_id().unwrap(),
+            context.get_farming_token_id() == context.get_reward_token_id(),
             ERROR_DIFFERENT_TOKEN_IDS
         );
-
-        self.load_reward_per_share(&mut context);
-        self.load_reward_reserve(&mut context);
-        self.load_block_nonce(&mut context);
-        self.load_block_epoch(&mut context);
-        self.load_farm_token_supply(&mut context);
-        self.load_division_safety_constant(&mut context);
-        self.load_farm_attributes(&mut context);
 
         self.generate_aggregated_rewards(context.get_storage_cache_mut());
         self.calculate_reward(&mut context);
         context.decrease_reward_reserve();
         self.calculate_initial_farming_amount(&mut context);
 
-        let virtual_position_amount = &context.get_tx_input().get_payments().get_first().amount
-            + context.get_position_reward().unwrap();
+        let tx_input = context.get_tx_input();
+        let virtual_position_amount =
+            &tx_input.first_payment.amount + context.get_position_reward();
         let virtual_position_token_amount = EsdtTokenPayment::new(
-            context.get_farm_token_id().unwrap().clone(),
+            context.get_farm_token_id().clone(),
             0,
             virtual_position_amount,
         );
 
-        let virtual_position_compounded_reward = self
-            .calculate_new_compound_reward_amount(&context)
-            + context.get_position_reward().unwrap();
+        let virtual_position_compounded_reward =
+            self.calculate_new_compound_reward_amount(&context) + context.get_position_reward();
         let virtual_position_current_farm_amount =
-            &context.get_tx_input().get_payments().get_first().amount
-                + context.get_position_reward().unwrap();
+            &tx_input.first_payment.amount + context.get_position_reward();
         let virtual_position_attributes = FarmTokenAttributes {
-            reward_per_share: context.get_reward_per_share().unwrap().clone(),
+            reward_per_share: context.get_reward_per_share().clone(),
             entering_epoch: context.get_block_epoch(),
             original_entering_epoch: context.get_block_epoch(),
-            initial_farming_amount: context.get_initial_farming_amount().unwrap().clone(),
+            initial_farming_amount: context.get_initial_farming_amount().clone(),
             compounded_reward: virtual_position_compounded_reward,
             current_farm_amount: virtual_position_current_farm_amount,
         };
@@ -354,11 +262,7 @@ pub trait Farm:
 
         let (new_farm_token, created_with_merge) = self.create_farm_tokens_by_merging(
             &virtual_position,
-            context
-                .get_tx_input()
-                .get_payments()
-                .get_additional()
-                .unwrap(),
+            &tx_input.additional_payments,
             context.get_storage_cache(),
         );
         context.set_output_position(new_farm_token, created_with_merge);
@@ -408,7 +312,7 @@ pub trait Farm:
 
         let new_amount = merged_attributes.current_farm_amount.clone();
         let new_tokens = self.mint_farm_tokens(
-            storage_cache.farm_token_id.clone().unwrap(),
+            storage_cache.farm_token_id.clone(),
             new_amount,
             &merged_attributes,
         );
@@ -433,19 +337,19 @@ pub trait Farm:
     }
 
     fn send_rewards(&self, context: &mut GenericContext<Self::Api>) {
-        if context.get_position_reward().unwrap() > &0u64 {
+        if context.get_position_reward() > &0u64 {
             self.send_tokens_non_zero(
                 context.get_caller(),
-                context.get_reward_token_id().unwrap(),
+                context.get_reward_token_id(),
                 0,
-                context.get_position_reward().unwrap(),
+                context.get_position_reward(),
             );
         }
 
         context.set_final_reward(EsdtTokenPayment::new(
-            context.get_reward_token_id().unwrap().clone(),
+            context.get_reward_token_id().clone(),
             0,
-            context.get_position_reward().unwrap().clone(),
+            context.get_position_reward().clone(),
         ));
     }
 
@@ -486,14 +390,13 @@ pub trait Farm:
     }
 
     fn burn_penalty(&self, context: &mut GenericContext<Self::Api>) {
-        if self.should_apply_penalty(context.get_input_attributes().unwrap().entering_epoch) {
-            let penalty_amount =
-                self.get_penalty_amount(context.get_initial_farming_amount().unwrap());
+        if self.should_apply_penalty(context.get_input_attributes().entering_epoch) {
+            let penalty_amount = self.get_penalty_amount(context.get_initial_farming_amount());
             if penalty_amount > 0u64 {
                 self.burn_farming_tokens(
-                    context.get_farming_token_id().unwrap(),
+                    context.get_farming_token_id(),
                     &penalty_amount,
-                    context.get_reward_token_id().unwrap(),
+                    context.get_reward_token_id(),
                 );
                 context.decrease_farming_token_amount(&penalty_amount);
             }
@@ -501,7 +404,7 @@ pub trait Farm:
     }
 
     fn burn_position(&self, context: &GenericContext<Self::Api>) {
-        let farm_token = context.get_tx_input().get_payments().get_first();
+        let farm_token = &context.get_tx_input().first_payment;
         self.burn_farm_tokens(
             &farm_token.token_identifier,
             farm_token.token_nonce,
@@ -510,10 +413,13 @@ pub trait Farm:
     }
 
     fn calculate_new_compound_reward_amount(&self, context: &GenericContext<Self::Api>) -> BigUint {
+        let first_payment = &context.get_tx_input().first_payment;
+        let attributes = context.get_input_attributes();
+
         self.rule_of_three(
-            &context.get_tx_input().get_payments().get_first().amount,
-            &context.get_input_attributes().unwrap().current_farm_amount,
-            &context.get_input_attributes().unwrap().compounded_reward,
+            &first_payment.amount,
+            &attributes.current_farm_amount,
+            &attributes.compounded_reward,
         )
     }
 }

--- a/dex/farm/wasm/src/lib.rs
+++ b/dex/farm/wasm/src/lib.rs
@@ -37,7 +37,6 @@ elrond_wasm_node::wasm_endpoints! {
         resume
         setFarmMigrationConfig
         setFarmTokenSupply
-        setLocalRolesFarmToken
         setPerBlockRewardAmount
         setRpsAndStartRewards
         set_burn_gas_limit

--- a/dex/farm_with_lock/Cargo.toml
+++ b/dex/farm_with_lock/Cargo.toml
@@ -47,5 +47,8 @@ path = "../../common/common_errors"
 [dependencies.elrond-wasm]
 version = "0.31.1"
 
+[dependencies.elrond-wasm-modules]
+version = "0.31.1"
+
 [dev-dependencies.elrond-wasm-debug]
 version = "0.31.1"

--- a/dex/farm_with_lock/src/custom_rewards.rs
+++ b/dex/farm_with_lock/src/custom_rewards.rs
@@ -11,6 +11,7 @@ pub trait CustomRewardsModule:
     + token_send::TokenSendModule
     + farm_token::FarmTokenModule
     + rewards::RewardsModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     fn mint_per_block_rewards(&self) -> BigUint {
         let current_block_nonce = self.blockchain().get_block_nonce();

--- a/dex/farm_with_lock/src/custom_rewards.rs
+++ b/dex/farm_with_lock/src/custom_rewards.rs
@@ -33,12 +33,12 @@ pub trait CustomRewardsModule:
         let total_reward = self.mint_per_block_rewards();
 
         if total_reward > 0u64 {
-            *storage.reward_reserve.as_mut().unwrap() += &total_reward;
+            storage.reward_reserve += &total_reward;
 
-            if storage.farm_token_supply.as_ref().unwrap() != &0u64 {
-                let increase = total_reward * storage.division_safety_constant.as_ref().unwrap()
-                    / storage.farm_token_supply.as_ref().unwrap();
-                *storage.reward_per_share.as_mut().unwrap() += &increase;
+            if storage.farm_token_supply != 0u64 {
+                let increase =
+                    total_reward * &storage.division_safety_constant / &storage.farm_token_supply;
+                storage.reward_per_share += &increase;
             }
         }
     }
@@ -46,23 +46,13 @@ pub trait CustomRewardsModule:
     #[only_owner]
     #[endpoint]
     fn end_produce_rewards(&self) {
-        // TODO: duplicated code
-        let mut storage = StorageCache {
-            reward_token_id: Some(self.reward_token_id().get()),
-            division_safety_constant: Some(self.division_safety_constant().get()),
-            farm_token_supply: Some(self.farm_token_supply().get()),
-            reward_reserve: Some(self.reward_reserve().get()),
-            reward_per_share: Some(self.reward_per_share().get()),
-            ..Default::default()
-        };
+        let mut storage = StorageCache::new(self);
 
         self.generate_aggregated_rewards(&mut storage);
-        self.reward_per_share()
-            .set(storage.reward_per_share.as_ref().unwrap());
-        self.reward_reserve()
-            .set(storage.reward_reserve.as_ref().unwrap());
+        self.reward_per_share().set(&storage.reward_per_share);
+        self.reward_reserve().set(&storage.reward_reserve);
 
-        self.produce_rewards_enabled().set(&false);
+        self.produce_rewards_enabled().set(false);
     }
 
     #[only_owner]
@@ -70,21 +60,11 @@ pub trait CustomRewardsModule:
     fn set_per_block_rewards(&self, per_block_amount: BigUint) {
         require!(per_block_amount != 0u64, ERROR_ZERO_AMOUNT);
 
-        // TODO: duplicated code
-        let mut storage = StorageCache {
-            reward_token_id: Some(self.reward_token_id().get()),
-            division_safety_constant: Some(self.division_safety_constant().get()),
-            farm_token_supply: Some(self.farm_token_supply().get()),
-            reward_reserve: Some(self.reward_reserve().get()),
-            reward_per_share: Some(self.reward_per_share().get()),
-            ..Default::default()
-        };
+        let mut storage = StorageCache::new(self);
 
         self.generate_aggregated_rewards(&mut storage);
-        self.reward_per_share()
-            .set(storage.reward_per_share.as_ref().unwrap());
-        self.reward_reserve()
-            .set(storage.reward_reserve.as_ref().unwrap());
+        self.reward_per_share().set(&storage.reward_per_share);
+        self.reward_reserve().set(&storage.reward_reserve);
 
         self.per_block_reward_amount().set(&per_block_amount);
     }

--- a/dex/farm_with_lock/src/farm_token_merge.rs
+++ b/dex/farm_with_lock/src/farm_token_merge.rs
@@ -13,6 +13,7 @@ pub trait FarmTokenMergeModule:
     + farm_token::FarmTokenModule
     + config::ConfigModule
     + token_merge::TokenMergeModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     #[payable("*")]
     #[endpoint(mergeFarmTokens)]
@@ -21,16 +22,21 @@ pub trait FarmTokenMergeModule:
         let payments = self.call_value().all_esdt_transfers();
 
         let attrs = self.get_merged_farm_token_attributes(&payments, Option::None);
-        let farm_token_id = self.farm_token_id().get();
+        let farm_token_id = self.farm_token().get_token_id();
         self.burn_farm_tokens_from_payments(&payments);
 
-        let new_nonce = self.mint_farm_tokens(&farm_token_id, &attrs.current_farm_amount, &attrs);
-        let new_amount = attrs.current_farm_amount;
+        let new_tokens =
+            self.mint_farm_tokens(farm_token_id, attrs.current_farm_amount.clone(), &attrs);
 
-        self.send()
-            .direct(&caller, &farm_token_id, new_nonce, &new_amount, &[]);
+        self.send().direct(
+            &caller,
+            &new_tokens.token_identifier,
+            new_tokens.token_nonce,
+            &new_tokens.amount,
+            &[],
+        );
 
-        EsdtTokenPayment::new(farm_token_id, new_nonce, new_amount)
+        new_tokens
     }
 
     fn get_merged_farm_token_attributes(
@@ -44,7 +50,7 @@ pub trait FarmTokenMergeModule:
         );
 
         let mut tokens = ManagedVec::new();
-        let farm_token_id = self.farm_token_id().get();
+        let farm_token_id = self.farm_token().get_token_id();
 
         for payment in payments.iter() {
             require!(payment.amount != 0u64, ERROR_ZERO_AMOUNT);
@@ -54,9 +60,9 @@ pub trait FarmTokenMergeModule:
             );
 
             let attributes =
-                self.get_farm_attributes(&payment.token_identifier, payment.token_nonce);
+                self.get_farm_token_attributes(&payment.token_identifier, payment.token_nonce);
             tokens.push(FarmToken {
-                token_amount: payment,
+                payment,
                 attributes,
             });
         }
@@ -86,7 +92,7 @@ pub trait FarmTokenMergeModule:
         tokens.iter().for_each(|x| {
             dataset.push(ValueWeight {
                 value: x.attributes.reward_per_share.clone(),
-                weight: x.token_amount.amount,
+                weight: x.payment.amount,
             })
         });
         self.weighted_average_ceil(dataset)
@@ -99,7 +105,7 @@ pub trait FarmTokenMergeModule:
         let mut sum = BigUint::zero();
         for x in tokens.iter() {
             sum += &self.rule_of_three_non_zero_result(
-                &x.token_amount.amount,
+                &x.payment.amount,
                 &x.attributes.current_farm_amount,
                 &x.attributes.initial_farming_amount,
             );
@@ -111,7 +117,7 @@ pub trait FarmTokenMergeModule:
         let mut sum = BigUint::zero();
         tokens.iter().for_each(|x| {
             sum += &self.rule_of_three(
-                &x.token_amount.amount,
+                &x.payment.amount,
                 &x.attributes.current_farm_amount,
                 &x.attributes.compounded_reward,
             )
@@ -123,7 +129,7 @@ pub trait FarmTokenMergeModule:
         let mut aggregated_amount = BigUint::zero();
         tokens
             .iter()
-            .for_each(|x| aggregated_amount += &x.token_amount.amount);
+            .for_each(|x| aggregated_amount += &x.payment.amount);
         aggregated_amount
     }
 
@@ -132,7 +138,7 @@ pub trait FarmTokenMergeModule:
         tokens.iter().for_each(|x| {
             dataset.push(ValueWeight {
                 value: BigUint::from(x.attributes.original_entering_epoch),
-                weight: x.token_amount.amount,
+                weight: x.payment.amount,
             })
         });
         let avg = self.weighted_average(dataset);

--- a/dex/farm_with_lock/src/lib.rs
+++ b/dex/farm_with_lock/src/lib.rs
@@ -84,44 +84,25 @@ pub trait Farm:
     fn enter_farm(&self) -> EnterFarmResultType<Self::Api> {
         let mut context = self.new_farm_context();
 
-        self.load_state(&mut context);
         require!(
-            context.get_contract_state().unwrap() == &State::Active,
+            context.get_contract_state() == State::Active,
             ERROR_NOT_ACTIVE
         );
-
-        self.load_farm_token_id(&mut context);
-        require!(
-            !context.get_farm_token_id().unwrap().is_empty(),
-            ERROR_NO_FARM_TOKEN
-        );
-
-        self.load_farming_token_id(&mut context);
+        require!(!context.get_farm_token_id().is_empty(), ERROR_NO_FARM_TOKEN);
         require!(context.is_accepted_payment_enter(), ERROR_BAD_PAYMENTS);
 
-        self.load_reward_reserve(&mut context);
-        self.load_reward_token_id(&mut context);
-        self.load_block_nonce(&mut context);
-        self.load_block_epoch(&mut context);
-        self.load_reward_per_share(&mut context);
-        self.load_farm_token_supply(&mut context);
-        self.load_division_safety_constant(&mut context);
         self.generate_aggregated_rewards(context.get_storage_cache_mut());
 
-        let first_payment_amount = context
-            .get_tx_input()
-            .get_payments()
-            .get_first()
-            .amount
-            .clone();
+        let tx_input = context.get_tx_input();
+        let first_payment_amount = tx_input.first_payment.amount.clone();
 
         let virtual_position_token_amount = EsdtTokenPayment::new(
-            context.get_farm_token_id().unwrap().clone(),
+            context.get_farm_token_id().clone(),
             0,
             first_payment_amount.clone(),
         );
         let virtual_position_attributes = FarmTokenAttributes {
-            reward_per_share: context.get_reward_per_share().unwrap().clone(),
+            reward_per_share: context.get_reward_per_share().clone(),
             entering_epoch: context.get_block_epoch(),
             original_entering_epoch: context.get_block_epoch(),
             initial_farming_amount: first_payment_amount.clone(),
@@ -135,11 +116,7 @@ pub trait Farm:
 
         let (new_farm_token, created_with_merge) = self.create_farm_tokens_by_merging(
             &virtual_position,
-            context
-                .get_tx_input()
-                .get_payments()
-                .get_additional()
-                .unwrap(),
+            &tx_input.additional_payments,
             context.get_storage_cache(),
         );
         context.set_output_position(new_farm_token, created_with_merge);
@@ -156,29 +133,12 @@ pub trait Farm:
     fn exit_farm(&self) -> ExitFarmResultType<Self::Api> {
         let mut context = self.new_farm_context();
 
-        self.load_state(&mut context);
         require!(
-            context.get_contract_state().unwrap() == &State::Active,
+            context.get_contract_state() == State::Active,
             ERROR_NOT_ACTIVE
         );
-
-        self.load_farm_token_id(&mut context);
-        require!(
-            !context.get_farm_token_id().unwrap().is_empty(),
-            ERROR_NO_FARM_TOKEN
-        );
-
-        self.load_farming_token_id(&mut context);
+        require!(!context.get_farm_token_id().is_empty(), ERROR_NO_FARM_TOKEN);
         require!(context.is_accepted_payment_exit(), ERROR_BAD_PAYMENTS);
-
-        self.load_reward_reserve(&mut context);
-        self.load_reward_token_id(&mut context);
-        self.load_block_nonce(&mut context);
-        self.load_block_epoch(&mut context);
-        self.load_reward_per_share(&mut context);
-        self.load_farm_token_supply(&mut context);
-        self.load_division_safety_constant(&mut context);
-        self.load_farm_attributes(&mut context);
 
         self.generate_aggregated_rewards(context.get_storage_cache_mut());
         self.calculate_reward(&mut context);
@@ -203,29 +163,12 @@ pub trait Farm:
     fn claim_rewards(&self) -> ClaimRewardsResultType<Self::Api> {
         let mut context = self.new_farm_context();
 
-        self.load_state(&mut context);
         require!(
-            context.get_contract_state().unwrap() == &State::Active,
+            context.get_contract_state() == State::Active,
             ERROR_NOT_ACTIVE
         );
-
-        self.load_farm_token_id(&mut context);
-        require!(
-            !context.get_farm_token_id().unwrap().is_empty(),
-            ERROR_NO_FARM_TOKEN
-        );
-
-        self.load_farming_token_id(&mut context);
+        require!(!context.get_farm_token_id().is_empty(), ERROR_NO_FARM_TOKEN);
         require!(context.is_accepted_payment_claim(), ERROR_BAD_PAYMENTS);
-
-        self.load_reward_reserve(&mut context);
-        self.load_reward_token_id(&mut context);
-        self.load_block_nonce(&mut context);
-        self.load_block_epoch(&mut context);
-        self.load_reward_per_share(&mut context);
-        self.load_farm_token_supply(&mut context);
-        self.load_division_safety_constant(&mut context);
-        self.load_farm_attributes(&mut context);
 
         self.generate_aggregated_rewards(context.get_storage_cache_mut());
         self.calculate_reward(&mut context);
@@ -234,31 +177,19 @@ pub trait Farm:
         self.calculate_initial_farming_amount(&mut context);
         let new_compound_reward_amount = self.calculate_new_compound_reward_amount(&context);
 
+        let tx_input = context.get_tx_input();
         let virtual_position_token_amount = EsdtTokenPayment::new(
-            context.get_farm_token_id().unwrap().clone(),
+            context.get_farm_token_id().clone(),
             0,
-            context
-                .get_tx_input()
-                .get_payments()
-                .get_first()
-                .amount
-                .clone(),
+            tx_input.first_payment.amount.clone(),
         );
         let virtual_position_attributes = FarmTokenAttributes {
-            reward_per_share: context.get_reward_per_share().unwrap().clone(),
-            entering_epoch: context.get_input_attributes().unwrap().entering_epoch,
-            original_entering_epoch: context
-                .get_input_attributes()
-                .unwrap()
-                .original_entering_epoch,
-            initial_farming_amount: context.get_initial_farming_amount().unwrap().clone(),
+            reward_per_share: context.get_reward_per_share().clone(),
+            entering_epoch: context.get_input_attributes().entering_epoch,
+            original_entering_epoch: context.get_input_attributes().original_entering_epoch,
+            initial_farming_amount: context.get_initial_farming_amount().clone(),
             compounded_reward: new_compound_reward_amount,
-            current_farm_amount: context
-                .get_tx_input()
-                .get_payments()
-                .get_first()
-                .amount
-                .clone(),
+            current_farm_amount: tx_input.first_payment.amount.clone(),
         };
         let virtual_position = FarmToken {
             payment: virtual_position_token_amount,
@@ -267,11 +198,7 @@ pub trait Farm:
 
         let (new_farm_token, created_with_merge) = self.create_farm_tokens_by_merging(
             &virtual_position,
-            context
-                .get_tx_input()
-                .get_payments()
-                .get_additional()
-                .unwrap(),
+            &tx_input.additional_payments,
             context.get_storage_cache(),
         );
         context.set_output_position(new_farm_token, created_with_merge);
@@ -291,66 +218,47 @@ pub trait Farm:
     fn compound_rewards(&self) -> CompoundRewardsResultType<Self::Api> {
         let mut context = self.new_farm_context();
 
-        self.load_state(&mut context);
         require!(
-            context.get_contract_state().unwrap() == &State::Active,
+            context.get_contract_state() == State::Active,
             ERROR_NOT_ACTIVE
         );
-
-        self.load_farm_token_id(&mut context);
-        require!(
-            !context.get_farm_token_id().unwrap().is_empty(),
-            ERROR_NO_FARM_TOKEN
-        );
-
-        self.load_farming_token_id(&mut context);
-        self.load_reward_token_id(&mut context);
+        require!(!context.get_farm_token_id().is_empty(), ERROR_NO_FARM_TOKEN);
         require!(context.is_accepted_payment_compound(), ERROR_BAD_PAYMENTS);
-
         require!(
-            context.get_farming_token_id().unwrap() == context.get_reward_token_id().unwrap(),
+            context.get_farming_token_id() == context.get_reward_token_id(),
             ERROR_DIFFERENT_TOKEN_IDS
         );
-
-        self.load_reward_reserve(&mut context);
-        self.load_block_nonce(&mut context);
-        self.load_block_epoch(&mut context);
-        self.load_reward_per_share(&mut context);
-        self.load_farm_token_supply(&mut context);
-        self.load_division_safety_constant(&mut context);
-        self.load_farm_attributes(&mut context);
 
         self.generate_aggregated_rewards(context.get_storage_cache_mut());
         self.calculate_reward(&mut context);
         context.decrease_reward_reserve();
         self.calculate_initial_farming_amount(&mut context);
 
-        let virtual_position_amount = &context.get_tx_input().get_payments().get_first().amount
-            + context.get_position_reward().unwrap();
+        let tx_input = context.get_tx_input();
+        let virtual_position_amount =
+            &tx_input.first_payment.amount + context.get_position_reward();
         let virtual_position_token_amount = EsdtTokenPayment::new(
-            context.get_farm_token_id().unwrap().clone(),
+            context.get_farm_token_id().clone(),
             0,
             virtual_position_amount,
         );
 
         let virtual_position_original_entering_epoch = self
             .aggregated_original_entering_epoch_on_compound(
-                context.get_farm_token_id().unwrap(),
-                &context.get_tx_input().get_payments().get_first().amount,
-                context.get_input_attributes().unwrap(),
-                context.get_position_reward().unwrap(),
+                context.get_farm_token_id(),
+                &tx_input.first_payment.amount,
+                context.get_input_attributes(),
+                context.get_position_reward(),
             );
-        let virtual_position_compounded_reward = self
-            .calculate_new_compound_reward_amount(&context)
-            + context.get_position_reward().unwrap();
+        let virtual_position_compounded_reward =
+            self.calculate_new_compound_reward_amount(&context) + context.get_position_reward();
         let virtual_position_current_farm_amount =
-            &context.get_tx_input().get_payments().get_first().amount
-                + context.get_position_reward().unwrap();
+            &tx_input.first_payment.amount + context.get_position_reward();
         let virtual_position_attributes = FarmTokenAttributes {
-            reward_per_share: context.get_reward_per_share().unwrap().clone(),
+            reward_per_share: context.get_reward_per_share().clone(),
             entering_epoch: context.get_block_epoch(),
             original_entering_epoch: virtual_position_original_entering_epoch,
-            initial_farming_amount: context.get_initial_farming_amount().unwrap().clone(),
+            initial_farming_amount: context.get_initial_farming_amount().clone(),
             compounded_reward: virtual_position_compounded_reward,
             current_farm_amount: virtual_position_current_farm_amount,
         };
@@ -362,11 +270,7 @@ pub trait Farm:
 
         let (new_farm_token, created_with_merge) = self.create_farm_tokens_by_merging(
             &virtual_position,
-            context
-                .get_tx_input()
-                .get_payments()
-                .get_additional()
-                .unwrap(),
+            &tx_input.additional_payments,
             context.get_storage_cache(),
         );
         context.set_output_position(new_farm_token, created_with_merge);
@@ -442,7 +346,7 @@ pub trait Farm:
 
         let new_amount = merged_attributes.current_farm_amount.clone();
         let new_tokens = self.mint_farm_tokens(
-            storage_cache.farm_token_id.clone().unwrap(),
+            storage_cache.farm_token_id.clone(),
             new_amount,
             &merged_attributes,
         );
@@ -467,22 +371,22 @@ pub trait Farm:
     }
 
     fn send_rewards(&self, context: &mut GenericContext<Self::Api>) {
-        if context.get_position_reward().unwrap() > &0u64 {
+        if context.get_position_reward() > &0u64 {
             let locked_asset_factory_address = self.locked_asset_factory_address().get();
             let result = self
                 .locked_asset_factory(locked_asset_factory_address)
                 .create_and_forward(
-                    context.get_position_reward().unwrap().clone(),
+                    context.get_position_reward().clone(),
                     context.get_caller().clone(),
-                    context.get_input_attributes().unwrap().entering_epoch,
+                    context.get_input_attributes().entering_epoch,
                 )
                 .execute_on_dest_context();
             context.set_final_reward(result);
         } else {
             context.set_final_reward(EsdtTokenPayment::new(
-                context.get_reward_token_id().unwrap().clone(),
+                context.get_reward_token_id().clone(),
                 0,
-                context.get_position_reward().unwrap().clone(),
+                context.get_position_reward().clone(),
             ));
         }
     }
@@ -526,14 +430,13 @@ pub trait Farm:
     }
 
     fn burn_penalty(&self, context: &mut GenericContext<Self::Api>) {
-        if self.should_apply_penalty(context.get_input_attributes().unwrap().entering_epoch) {
-            let penalty_amount =
-                self.get_penalty_amount(context.get_initial_farming_amount().unwrap());
+        if self.should_apply_penalty(context.get_input_attributes().entering_epoch) {
+            let penalty_amount = self.get_penalty_amount(context.get_initial_farming_amount());
             if penalty_amount > 0u64 {
                 self.burn_farming_tokens(
-                    context.get_farming_token_id().unwrap(),
+                    context.get_farming_token_id(),
                     &penalty_amount,
-                    context.get_reward_token_id().unwrap(),
+                    context.get_reward_token_id(),
                 );
                 context.decrease_farming_token_amount(&penalty_amount);
             }
@@ -541,7 +444,7 @@ pub trait Farm:
     }
 
     fn burn_position(&self, context: &GenericContext<Self::Api>) {
-        let farm_token = context.get_tx_input().get_payments().get_first();
+        let farm_token = &context.get_tx_input().first_payment;
         self.burn_farm_tokens(
             &farm_token.token_identifier,
             farm_token.token_nonce,
@@ -550,10 +453,13 @@ pub trait Farm:
     }
 
     fn calculate_new_compound_reward_amount(&self, context: &GenericContext<Self::Api>) -> BigUint {
+        let first_payment = &context.get_tx_input().first_payment;
+        let attributes = context.get_input_attributes();
+
         self.rule_of_three(
-            &context.get_tx_input().get_payments().get_first().amount,
-            &context.get_input_attributes().unwrap().current_farm_amount,
-            &context.get_input_attributes().unwrap().compounded_reward,
+            &first_payment.amount,
+            &attributes.current_farm_amount,
+            &attributes.compounded_reward,
         )
     }
 }

--- a/dex/farm_with_lock/wasm/src/lib.rs
+++ b/dex/farm_with_lock/wasm/src/lib.rs
@@ -37,7 +37,6 @@ elrond_wasm_node::wasm_endpoints! {
         resume
         setFarmMigrationConfig
         setFarmTokenSupply
-        setLocalRolesFarmToken
         setPerBlockRewardAmount
         setRpsAndStartRewards
         set_burn_gas_limit

--- a/dex/fuzz/Cargo.toml
+++ b/dex/fuzz/Cargo.toml
@@ -16,6 +16,9 @@ version = "0.31.1"
 [dependencies.config]
 path = "../../common/modules/farm/config"
 
+[dependencies.farm_token]
+path = "../../common/modules/farm/farm_token"
+
 [dependencies.rewards]
 path = "../../common/modules/farm/rewards"
 

--- a/dex/fuzz/src/fuzz_data.rs
+++ b/dex/fuzz/src/fuzz_data.rs
@@ -18,6 +18,7 @@ pub mod fuzz_data_tests {
     use factory::locked_asset::LockedAssetModule;
     use factory::*;
     use farm::*;
+    use farm_token::FarmTokenModule;
     use pair::*;
     use price_discovery::redeem_token::*;
     use price_discovery::*;
@@ -438,7 +439,7 @@ pub mod fuzz_data_tests {
                 );
 
                 let farm_token_id = managed_token_id!(farm_token);
-                sc.farm_token_id().set(&farm_token_id);
+                sc.farm_token().set_token_id(&farm_token_id);
 
                 sc.per_block_reward_amount()
                     .set(&to_managed_biguint(per_block_reward_amount));

--- a/dex/tests/farm_review_distribution.rs
+++ b/dex/tests/farm_review_distribution.rs
@@ -1,5 +1,6 @@
 use std::ops::Mul;
 
+use elrond_wasm::storage::mappers::StorageTokenWrapper;
 use elrond_wasm::types::{Address, BigUint, EsdtLocalRole};
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_token_id, rust_biguint, testing_framework::*,
@@ -10,6 +11,7 @@ type RustBigUint = num_bigint::BigUint;
 use config::*;
 use custom_rewards::*;
 use farm::*;
+use farm_token::FarmTokenModule;
 use rewards::*;
 
 const FARM_WASM_PATH: &'static str = "farm/output/farm.wasm";
@@ -65,7 +67,7 @@ where
             );
 
             let farm_token_id = managed_token_id!(FARM_TOKEN_ID);
-            sc.farm_token_id().set(&farm_token_id);
+            sc.farm_token().set_token_id(&farm_token_id);
 
             sc.per_block_reward_amount()
                 .set(&to_managed_biguint(per_block_reward_amount));

--- a/dex/tests/farm_rs_test.rs
+++ b/dex/tests/farm_rs_test.rs
@@ -1,4 +1,5 @@
 use common_structs::FarmTokenAttributes;
+use elrond_wasm::storage::mappers::StorageTokenWrapper;
 use elrond_wasm::types::{Address, EsdtLocalRole, EsdtTokenPayment};
 use elrond_wasm_debug::tx_mock::{TxContextStack, TxInputESDT};
 use elrond_wasm_debug::{
@@ -11,6 +12,7 @@ use migration_from_v1_2::{FarmTokenAttributesV1_2, MigrationModule};
 
 use config::*;
 use farm::*;
+use farm_token::FarmTokenModule;
 
 // const GENERATED_FILE_PREFIX: &'static str = "_generated_";
 // const MANDOS_FILE_EXTENSION: &'static str = ".scen.json";
@@ -70,7 +72,7 @@ where
             );
 
             let farm_token_id = managed_token_id!(FARM_TOKEN_ID);
-            sc.farm_token_id().set(&farm_token_id);
+            sc.farm_token().set_token_id(&farm_token_id);
 
             sc.per_block_reward_amount()
                 .set(&managed_biguint!(PER_BLOCK_REWARD_AMOUNT));

--- a/dex/tests/farm_with_lock_review_distribution.rs
+++ b/dex/tests/farm_with_lock_review_distribution.rs
@@ -3,6 +3,7 @@ use std::ops::Mul;
 use common_structs::{
     LockedAssetTokenAttributesEx, UnlockMilestone, UnlockMilestoneEx, UnlockScheduleEx,
 };
+use elrond_wasm::storage::mappers::StorageTokenWrapper;
 use elrond_wasm::types::{
     Address, BigUint, EsdtLocalRole, ManagedAddress, ManagedVec, MultiValueEncoded,
 };
@@ -17,6 +18,7 @@ type RustBigUint = num_bigint::BigUint;
 use config::*;
 use factory::locked_asset::LockedAssetModule;
 use factory::*;
+use farm_token::FarmTokenModule;
 use farm_with_lock::custom_rewards::CustomRewardsModule;
 use farm_with_lock::*;
 use rewards::*;
@@ -136,7 +138,7 @@ where
             );
 
             let farm_token_id = managed_token_id!(FARM_TOKEN_ID);
-            sc.farm_token_id().set(&farm_token_id);
+            sc.farm_token().set_token_id(&farm_token_id);
 
             sc.per_block_reward_amount()
                 .set(&to_managed_biguint(per_block_reward_amount));

--- a/farm-staking/farm-staking-proxy/Cargo.toml
+++ b/farm-staking/farm-staking-proxy/Cargo.toml
@@ -40,3 +40,6 @@ path = "../../common/modules/farm/config"
 
 [dependencies.rewards]
 path = "../../common/modules/farm/rewards"
+
+[dev-dependencies.farm_token]
+path = "../../common/modules/farm/farm_token"

--- a/farm-staking/farm-staking-proxy/Cargo.toml
+++ b/farm-staking/farm-staking-proxy/Cargo.toml
@@ -11,6 +11,9 @@ path = "src/lib.rs"
 [dependencies.elrond-wasm]
 version = "0.31.1"
 
+[dependencies.elrond-wasm-modules]
+version = "0.31.1"
+
 [dependencies]
 hex-literal = "0.3.1"
 

--- a/farm-staking/farm-staking-proxy/src/dual_yield_token.rs
+++ b/farm-staking/farm-staking-proxy/src/dual_yield_token.rs
@@ -19,7 +19,10 @@ impl<M: ManagedTypeApi> DualYieldTokenAttributes<M> {
 }
 
 #[elrond_wasm::module]
-pub trait DualYieldTokenModule: token_merge::TokenMergeModule {
+pub trait DualYieldTokenModule:
+    token_merge::TokenMergeModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
+{
     #[only_owner]
     #[payable("EGLD")]
     #[endpoint(registerDualYieldToken)]
@@ -29,118 +32,15 @@ pub trait DualYieldTokenModule: token_merge::TokenMergeModule {
         token_ticker: ManagedBuffer,
         num_decimals: usize,
     ) {
-        require!(
-            self.dual_yield_token_id().is_empty(),
-            "Token already issued"
-        );
-
         let register_cost = self.call_value().egld_value();
-
-        self.register_token(
+        self.dual_yield_token().issue_and_set_all_roles(
+            EsdtTokenType::Meta,
             register_cost,
             token_display_name,
             token_ticker,
             num_decimals,
-        )
-    }
-
-    fn register_token(
-        &self,
-        register_cost: BigUint,
-        token_display_name: ManagedBuffer,
-        token_ticker: ManagedBuffer,
-        num_decimals: usize,
-    ) {
-        self.send()
-            .esdt_system_sc_proxy()
-            .register_meta_esdt(
-                register_cost,
-                &token_display_name,
-                &token_ticker,
-                MetaTokenProperties {
-                    num_decimals,
-                    can_freeze: true,
-                    can_wipe: true,
-                    can_pause: true,
-                    can_change_owner: true,
-                    can_upgrade: true,
-                    can_add_special_roles: true,
-                },
-            )
-            .async_call()
-            .with_callback(
-                self.callbacks()
-                    .register_callback(&self.blockchain().get_caller()),
-            )
-            .call_and_exit()
-    }
-
-    #[callback]
-    fn register_callback(
-        &self,
-        caller: &ManagedAddress,
-        #[call_result] result: ManagedAsyncCallResult<TokenIdentifier>,
-    ) {
-        match result {
-            ManagedAsyncCallResult::Ok(token_id) => {
-                self.dual_yield_token_id().set_if_empty(&token_id);
-            }
-            ManagedAsyncCallResult::Err(_) => {
-                let (returned_tokens, token_id) = self.call_value().payment_token_pair();
-                if token_id.is_egld() && returned_tokens > 0 {
-                    let _ = self.send().direct_egld(caller, &returned_tokens, &[]);
-                }
-            }
-        }
-    }
-
-    #[only_owner]
-    #[endpoint(setLocalRolesDualYieldToken)]
-    fn set_local_roles_dual_yield_token(&self) {
-        require!(!self.dual_yield_token_id().is_empty(), "No farm token");
-
-        let token = self.dual_yield_token_id().get();
-        self.set_local_roles(token)
-    }
-
-    fn set_local_roles(&self, token: TokenIdentifier) {
-        let roles = [
-            EsdtLocalRole::NftCreate,
-            EsdtLocalRole::NftAddQuantity,
-            EsdtLocalRole::NftBurn,
-        ];
-
-        self.send()
-            .esdt_system_sc_proxy()
-            .set_special_roles(
-                &self.blockchain().get_sc_address(),
-                &token,
-                roles.iter().cloned(),
-            )
-            .async_call()
-            .call_and_exit()
-    }
-
-    fn require_dual_yield_token(&self, token_id: &TokenIdentifier) {
-        let dual_yield_token_id = self.dual_yield_token_id().get();
-        require!(token_id == &dual_yield_token_id, "Invalid payment token");
-    }
-
-    fn require_all_payments_dual_yield_tokens(
-        &self,
-        payments: &ManagedVec<EsdtTokenPayment<Self::Api>>,
-    ) {
-        if payments.is_empty() {
-            return;
-        }
-
-        let dual_yield_token_id = self.dual_yield_token_id().get();
-        for p in payments {
-            require!(
-                p.token_identifier == dual_yield_token_id,
-                "Invalid payment token"
-            );
-        }
+            None,
+        );
     }
 
     fn create_and_send_dual_yield_tokens(
@@ -175,8 +75,6 @@ pub trait DualYieldTokenModule: token_merge::TokenMergeModule {
         staking_farm_token_nonce: u64,
         staking_farm_token_amount: BigUint,
     ) -> EsdtTokenPayment<Self::Api> {
-        let dual_yield_token_id = self.dual_yield_token_id().get();
-        let empty_buffer = ManagedBuffer::new();
         let attributes = DualYieldTokenAttributes {
             lp_farm_token_nonce,
             lp_farm_token_amount,
@@ -184,38 +82,23 @@ pub trait DualYieldTokenModule: token_merge::TokenMergeModule {
             staking_farm_token_amount,
         };
         let amount = attributes.get_total_dual_yield_tokens_for_position();
-        let new_token_nonce = self.send().esdt_nft_create(
-            &dual_yield_token_id,
-            amount,
-            &empty_buffer,
-            &BigUint::zero(),
-            &empty_buffer,
-            &attributes,
-            &ManagedVec::new(),
-        );
 
-        EsdtTokenPayment::new(dual_yield_token_id, new_token_nonce, amount.clone())
+        self.dual_yield_token()
+            .nft_create(amount.clone(), &attributes)
     }
 
+    #[inline]
     fn burn_dual_yield_tokens(&self, sft_nonce: u64, amount: &BigUint) {
-        let dual_yield_token_id = self.dual_yield_token_id().get();
-        self.send()
-            .esdt_local_burn(&dual_yield_token_id, sft_nonce, amount);
+        self.dual_yield_token().nft_burn(sft_nonce, amount)
     }
 
+    #[inline]
     fn get_dual_yield_token_attributes(
         &self,
         dual_yield_token_nonce: u64,
     ) -> DualYieldTokenAttributes<Self::Api> {
-        let own_sc_address = self.blockchain().get_sc_address();
-        let dual_yield_token_id = self.dual_yield_token_id().get();
-        let token_info = self.blockchain().get_esdt_token_data(
-            &own_sc_address,
-            &dual_yield_token_id,
-            dual_yield_token_nonce,
-        );
-
-        token_info.decode_attributes()
+        self.dual_yield_token()
+            .get_token_attributes(dual_yield_token_nonce)
     }
 
     fn get_lp_farm_token_amount_equivalent(
@@ -239,5 +122,5 @@ pub trait DualYieldTokenModule: token_merge::TokenMergeModule {
 
     #[view(getDualYieldTokenId)]
     #[storage_mapper("dualYieldTokenId")]
-    fn dual_yield_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
+    fn dual_yield_token(&self) -> NonFungibleTokenMapper<Self::Api>;
 }

--- a/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_external_contracts/mod.rs
+++ b/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_external_contracts/mod.rs
@@ -1,4 +1,5 @@
 use elrond_wasm::elrond_codec::multi_types::{MultiValue3, OptionalValue};
+use elrond_wasm::storage::mappers::StorageTokenWrapper;
 use elrond_wasm::types::{Address, EsdtLocalRole};
 use elrond_wasm_debug::tx_mock::TxInputESDT;
 use elrond_wasm_debug::{
@@ -14,6 +15,7 @@ use pair_config::ConfigModule as _;
 use ::config as farm_config;
 use farm::*;
 use farm_config::ConfigModule as _;
+use farm_token::FarmTokenModule;
 
 use crate::constants::*;
 
@@ -220,7 +222,7 @@ where
             );
 
             let farm_token_id = managed_token_id!(LP_FARM_TOKEN_ID);
-            sc.farm_token_id().set(&farm_token_id);
+            sc.farm_token().set_token_id(&farm_token_id);
 
             sc.minimum_farming_epochs().set(&MIN_FARMING_EPOCHS);
             sc.penalty_percent().set(&PENALTY_PERCENT);

--- a/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_setup/mod.rs
+++ b/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_setup/mod.rs
@@ -117,8 +117,8 @@ where
                 managed_token_id!(LP_TOKEN_ID),
             );
 
-            sc.dual_yield_token_id()
-                .set(&managed_token_id!(DUAL_YIELD_TOKEN_ID));
+            sc.dual_yield_token()
+                .set_token_id(&managed_token_id!(DUAL_YIELD_TOKEN_ID));
         })
         .assert_ok();
 

--- a/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_setup/mod.rs
+++ b/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_setup/mod.rs
@@ -1,3 +1,4 @@
+use elrond_wasm::storage::mappers::StorageTokenWrapper;
 use elrond_wasm::types::{Address, EsdtLocalRole};
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_token_id, rust_biguint,
@@ -13,6 +14,7 @@ use farm_staking_config::ConfigModule as _;
 use farm_staking::custom_rewards::CustomRewardsModule;
 use farm_staking_proxy::dual_yield_token::DualYieldTokenModule;
 use farm_staking_proxy::*;
+use farm_token::FarmTokenModule;
 
 use crate::constants::*;
 
@@ -36,8 +38,8 @@ where
 
             sc.init(farming_token_id, div_const, max_apr, UNBOND_EPOCHS);
 
-            sc.farm_token_id()
-                .set(&managed_token_id!(STAKING_FARM_TOKEN_ID));
+            sc.farm_token()
+                .set_token_id(&managed_token_id!(STAKING_FARM_TOKEN_ID));
 
             sc.state().set(&farm_staking_config::State::Active);
             sc.produce_rewards_enabled().set(&true);

--- a/farm-staking/farm-staking/Cargo.toml
+++ b/farm-staking/farm-staking/Cargo.toml
@@ -38,6 +38,9 @@ path = "../../common/common_errors"
 [dependencies.elrond-wasm]
 version = "0.31.1"
 
+[dependencies.elrond-wasm-modules]
+version = "0.31.1"
+
 [dev-dependencies.elrond-wasm-debug]
 version = "0.31.1"
 

--- a/farm-staking/farm-staking/src/custom_rewards.rs
+++ b/farm-staking/farm-staking/src/custom_rewards.rs
@@ -8,7 +8,10 @@ pub const BLOCKS_IN_YEAR: u64 = 31_536_000 / 6; // seconds_in_year / 6_seconds_p
 
 #[elrond_wasm::module]
 pub trait CustomRewardsModule:
-    config::ConfigModule + token_send::TokenSendModule + farm_token::FarmTokenModule
+    config::ConfigModule
+    + token_send::TokenSendModule
+    + farm_token::FarmTokenModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     fn calculate_extra_rewards_since_last_allocation(&self) -> BigUint {
         let current_block_nonce = self.blockchain().get_block_nonce();

--- a/farm-staking/farm-staking/tests/farm_staking_test.rs
+++ b/farm-staking/farm-staking/tests/farm_staking_test.rs
@@ -1,3 +1,4 @@
+use elrond_wasm::storage::mappers::StorageTokenWrapper;
 use elrond_wasm::types::{Address, EsdtLocalRole};
 use elrond_wasm_debug::tx_mock::{TxContextStack, TxInputESDT};
 use elrond_wasm_debug::{
@@ -10,6 +11,7 @@ use config::*;
 use farm_staking::custom_rewards::{CustomRewardsModule, BLOCKS_IN_YEAR};
 use farm_staking::farm_token_merge::StakingFarmTokenAttributes;
 use farm_staking::*;
+use farm_token::FarmTokenModule;
 
 const FARM_WASM_PATH: &'static str = "farm/output/farm-staking.wasm";
 
@@ -66,7 +68,7 @@ where
             );
 
             let farm_token_id = managed_token_id!(FARM_TOKEN_ID);
-            sc.farm_token_id().set(&farm_token_id);
+            sc.farm_token().set_token_id(&farm_token_id);
 
             sc.per_block_reward_amount()
                 .set(&managed_biguint!(PER_BLOCK_REWARD_AMOUNT));


### PR DESCRIPTION
- use NonFungibleTokenMapper for `farm_token` and `dual_yield_token`
- refactor contexts to always load everything and not use options