### PR TITLE
farm admin actions

### DIFF
--- a/common/modules/admin_whitelist/Cargo.toml
+++ b/common/modules/admin_whitelist/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "admin_whitelist"
+version = "0.0.0"
+authors = [ "Dorin Iancu <dorin.iancu@elrond.com>" ]
+edition = "2018"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies.elrond-wasm]
+version = "0.33.0"

--- a/common/modules/admin_whitelist/src/lib.rs
+++ b/common/modules/admin_whitelist/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 elrond_wasm::imports!();
 
 #[elrond_wasm::module]

--- a/common/modules/admin_whitelist/src/lib.rs
+++ b/common/modules/admin_whitelist/src/lib.rs
@@ -1,0 +1,40 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait AdminWhitelistModule {
+    #[only_owner]
+    #[endpoint(addAdmins)]
+    fn add_admins(&self, admins: MultiValueEncoded<ManagedAddress>) {
+        let mut whitelist = self.admins();
+        for admin in admins {
+            let _ = whitelist.insert(admin);
+        }
+    }
+
+    #[only_owner]
+    #[endpoint(removeAdmins)]
+    fn remove_admins(&self, admins: MultiValueEncoded<ManagedAddress>) {
+        let mut whitelist = self.admins();
+        for admin in admins {
+            let _ = whitelist.swap_remove(&admin);
+        }
+    }
+
+    fn require_caller_is_admin(&self) {
+        let caller = self.blockchain().get_caller();
+        require!(self.admins().contains(&caller), "Caller is not an admin");
+    }
+
+    fn require_caller_is_owner_or_admin(&self) {
+        let caller = self.blockchain().get_caller();
+        let owner = self.blockchain().get_owner_address();
+        require!(
+            caller == owner || self.admins().contains(&caller),
+            "Caller is not owner or an admin"
+        );
+    }
+
+    #[view(getAdmins)]
+    #[storage_mapper("admins")]
+    fn admins(&self) -> UnorderedSetMapper<ManagedAddress>;
+}

--- a/common/modules/farm/config/Cargo.toml
+++ b/common/modules/farm/config/Cargo.toml
@@ -19,5 +19,8 @@ path = "../../token_send"
 [dependencies.pausable]
 path = "../../pausable"
 
+[dependencies.admin_whitelist]
+path = "../../admin_whitelist"
+
 [dependencies.elrond-wasm]
 version = "0.33.0"

--- a/common/modules/farm/contexts/Cargo.toml
+++ b/common/modules/farm/contexts/Cargo.toml
@@ -31,6 +31,9 @@ path = "../config"
 [dependencies.pausable]
 path = "../../pausable"
 
+[dependencies.admin_whitelist]
+path = "../../admin_whitelist"
+
 [dependencies.elrond-wasm]
 version = "0.33.0"
 

--- a/common/modules/farm/contexts/src/ctx_helper.rs
+++ b/common/modules/farm/contexts/src/ctx_helper.rs
@@ -11,6 +11,7 @@ pub trait CtxHelper:
     + farm_token::FarmTokenModule
     + token_merge::TokenMergeModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     fn new_farm_context(&self) -> GenericContext<Self::Api> {

--- a/common/modules/farm/farm_token/Cargo.toml
+++ b/common/modules/farm/farm_token/Cargo.toml
@@ -22,6 +22,9 @@ path = "../../token_send"
 [dependencies.pausable]
 path = "../../pausable"
 
+[dependencies.admin_whitelist]
+path = "../../admin_whitelist"
+
 [dependencies.elrond-wasm]
 version = "0.33.0"
 

--- a/common/modules/farm/farm_token/src/farm_token.rs
+++ b/common/modules/farm/farm_token/src/farm_token.rs
@@ -17,10 +17,10 @@ pub struct FarmToken<M: ManagedTypeApi> {
 pub trait FarmTokenModule:
     config::ConfigModule
     + token_send::TokenSendModule
-    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
-    #[only_owner]
     #[payable("EGLD")]
     #[endpoint(registerFarmToken)]
     fn register_farm_token(
@@ -29,6 +29,8 @@ pub trait FarmTokenModule:
         token_ticker: ManagedBuffer,
         num_decimals: usize,
     ) {
+        self.require_caller_is_owner_or_admin();
+
         let payment_amount = self.call_value().egld_value();
         self.farm_token().issue_and_set_all_roles(
             EsdtTokenType::Meta,

--- a/common/modules/farm/migration_from_v1_2/Cargo.toml
+++ b/common/modules/farm/migration_from_v1_2/Cargo.toml
@@ -28,6 +28,9 @@ path = "../rewards"
 [dependencies.pausable]
 path = "../../pausable"
 
+[dependencies.admin_whitelist]
+path = "../../admin_whitelist"
+
 [dependencies.elrond-wasm]
 version = "0.33.0"
 

--- a/common/modules/farm/migration_from_v1_2/src/lib.rs
+++ b/common/modules/farm/migration_from_v1_2/src/lib.rs
@@ -26,6 +26,7 @@ pub trait MigrationModule:
     + farm_token::FarmTokenModule
     + rewards::RewardsModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     #[payable("*")]

--- a/common/modules/farm/rewards/Cargo.toml
+++ b/common/modules/farm/rewards/Cargo.toml
@@ -25,6 +25,9 @@ path = "../../token_send"
 [dependencies.pausable]
 path = "../../pausable"
 
+[dependencies.admin_whitelist]
+path = "../../admin_whitelist"
+
 [dependencies.elrond-wasm]
 version = "0.33.0"
 

--- a/common/modules/farm/rewards/src/rewards.rs
+++ b/common/modules/farm/rewards/src/rewards.rs
@@ -11,6 +11,7 @@ pub trait RewardsModule:
     + farm_token::FarmTokenModule
     + token_send::TokenSendModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     fn calculate_per_block_rewards(
@@ -28,9 +29,9 @@ pub trait RewardsModule:
         per_block_reward * block_nonce_diff
     }
 
-    #[only_owner]
     #[endpoint(startProduceRewards)]
-    fn start_produce_rewards_as_owner(&self) {
+    fn start_produce_rewards_endpoint(&self) {
+        self.require_caller_is_admin();
         self.start_produce_rewards();
     }
 
@@ -44,11 +45,11 @@ pub trait RewardsModule:
             "Producing rewards is already enabled"
         );
         let current_nonce = self.blockchain().get_block_nonce();
-        self.produce_rewards_enabled().set(&true);
-        self.last_reward_block_nonce().set(&current_nonce);
+        self.produce_rewards_enabled().set(true);
+        self.last_reward_block_nonce().set(current_nonce);
     }
 
-    #[inline(always)]
+    #[inline]
     fn produces_per_block_rewards(&self) -> bool {
         self.produce_rewards_enabled().get()
     }

--- a/dex/farm/Cargo.toml
+++ b/dex/farm/Cargo.toml
@@ -35,6 +35,9 @@ path = "../../common/modules/token_merge"
 [dependencies.pausable]
 path = "../../common/modules/pausable"
 
+[dependencies.admin_whitelist]
+path = "../../common/modules/admin_whitelist"
+
 [dependencies.factory]
 path = "../../locked-asset/factory"
 

--- a/dex/farm/src/custom_rewards.rs
+++ b/dex/farm/src/custom_rewards.rs
@@ -12,6 +12,7 @@ pub trait CustomRewardsModule:
     + farm_token::FarmTokenModule
     + rewards::RewardsModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     fn mint_per_block_rewards(&self, token_id: &TokenIdentifier) -> BigUint {
@@ -45,9 +46,10 @@ pub trait CustomRewardsModule:
         }
     }
 
-    #[only_owner]
     #[endpoint]
     fn end_produce_rewards(&self) {
+        self.require_caller_is_admin();
+
         let mut storage = StorageCache::new(self);
 
         self.generate_aggregated_rewards(&mut storage);
@@ -57,9 +59,9 @@ pub trait CustomRewardsModule:
         self.produce_rewards_enabled().set(false);
     }
 
-    #[only_owner]
     #[endpoint(setPerBlockRewardAmount)]
     fn set_per_block_rewards(&self, per_block_amount: BigUint) {
+        self.require_caller_is_admin();
         require!(per_block_amount != 0u64, ERROR_ZERO_AMOUNT);
 
         let mut storage = StorageCache::new(self);

--- a/dex/farm/src/farm_token_merge.rs
+++ b/dex/farm/src/farm_token_merge.rs
@@ -14,6 +14,7 @@ pub trait FarmTokenMergeModule:
     + config::ConfigModule
     + token_merge::TokenMergeModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     #[payable("*")]

--- a/dex/farm_with_lock/Cargo.toml
+++ b/dex/farm_with_lock/Cargo.toml
@@ -35,6 +35,9 @@ path = "../../common/modules/token_merge"
 [dependencies.pausable]
 path = "../../common/modules/pausable"
 
+[dependencies.admin_whitelist]
+path = "../../common/modules/admin_whitelist"
+
 [dependencies.factory]
 path = "../../locked-asset/factory"
 

--- a/dex/farm_with_lock/src/custom_rewards.rs
+++ b/dex/farm_with_lock/src/custom_rewards.rs
@@ -12,6 +12,7 @@ pub trait CustomRewardsModule:
     + farm_token::FarmTokenModule
     + rewards::RewardsModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     fn mint_per_block_rewards(&self) -> BigUint {

--- a/dex/farm_with_lock/src/farm_token_merge.rs
+++ b/dex/farm_with_lock/src/farm_token_merge.rs
@@ -14,6 +14,7 @@ pub trait FarmTokenMergeModule:
     + config::ConfigModule
     + token_merge::TokenMergeModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     #[payable("*")]

--- a/dex/farm_with_lock/src/lib.rs
+++ b/dex/farm_with_lock/src/lib.rs
@@ -36,6 +36,7 @@ pub trait Farm:
     + farm_token::FarmTokenModule
     + farm_token_merge::FarmTokenMergeModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + events::EventsModule
     + contexts::ctx_helper::CtxHelper
     + migration_from_v1_2::MigrationModule

--- a/dex/fuzz/src/fuzz_data.rs
+++ b/dex/fuzz/src/fuzz_data.rs
@@ -45,7 +45,7 @@ pub mod fuzz_data_tests {
     pub const MEX_FARM_TOKEN_ID: &[u8] = b"MEXFARM-abcdef";
     pub const LOCKED_MEX_TOKEN_ID: &[u8] = b"LKMEX-abcdef";
     pub const FACTORY_LOCK_NONCE: u64 = 1;
-    pub const MIN_FARMING_EPOCHS: u8 = 2;
+    pub const MIN_FARMING_EPOCHS: u64 = 2;
     pub const FARM_PENALTY_PERCENT: u64 = 10;
     pub const OWNER_EGLD_BALANCE: u64 = 100_000_000;
     pub const USER_TOTAL_MEX_TOKENS: u64 = 100_000_000_000;
@@ -438,6 +438,7 @@ pub mod fuzz_data_tests {
                     farming_token_id,
                     division_safety_constant,
                     pair_address,
+                    MultiValueEncoded::new(),
                 );
 
                 let farm_token_id = managed_token_id!(farm_token);
@@ -445,8 +446,8 @@ pub mod fuzz_data_tests {
 
                 sc.per_block_reward_amount()
                     .set(&to_managed_biguint(per_block_reward_amount));
-                sc.minimum_farming_epochs().set(&MIN_FARMING_EPOCHS);
-                sc.penalty_percent().set(&FARM_PENALTY_PERCENT);
+                sc.minimum_farming_epochs().set(MIN_FARMING_EPOCHS);
+                sc.penalty_percent().set(FARM_PENALTY_PERCENT);
 
                 sc.state().set(&State::Active);
                 sc.produce_rewards_enabled().set(&true);

--- a/dex/mandos/farm_reward_distr_scen_3.scen.json
+++ b/dex/mandos/farm_reward_distr_scen_3.scen.json
@@ -72,6 +72,27 @@
             }
         },
         {
+            "step": "scCall",
+            "txId": "add-admin",
+            "tx": {
+                "from": "address:alice",
+                "to": "sc:farm_contract",
+                "function": "addAdmins",
+                "arguments": [
+                    "address:alice"
+                ],
+                "gasLimit": "100,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
             "step": "setState",
             "currentBlockInfo": {
                 "blockNonce": "3"

--- a/dex/mandos/farm_reward_distr_scen_4.scen.json
+++ b/dex/mandos/farm_reward_distr_scen_4.scen.json
@@ -72,6 +72,27 @@
             }
         },
         {
+            "step": "scCall",
+            "txId": "add-admin",
+            "tx": {
+                "from": "address:alice",
+                "to": "sc:farm_contract",
+                "function": "addAdmins",
+                "arguments": [
+                    "address:alice"
+                ],
+                "gasLimit": "100,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
             "step": "setState",
             "currentBlockInfo": {
                 "blockNonce": "3"

--- a/dex/tests/farm_review_distribution.rs
+++ b/dex/tests/farm_review_distribution.rs
@@ -1,7 +1,7 @@
 use std::ops::Mul;
 
 use elrond_wasm::storage::mappers::StorageTokenWrapper;
-use elrond_wasm::types::{Address, BigUint, EsdtLocalRole};
+use elrond_wasm::types::{Address, BigUint, EsdtLocalRole, MultiValueEncoded};
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_token_id, rust_biguint, testing_framework::*,
     tx_mock::TxInputESDT, DebugApi,
@@ -21,7 +21,7 @@ const MEX_TOKEN_ID: &[u8] = b"MEX-abcdef"; // reward token ID
 const LP_TOKEN_ID: &[u8] = b"LPTOK-abcdef"; // farming token ID
 const FARM_TOKEN_ID: &[u8] = b"FARM-abcdef";
 const DIVISION_SAFETY_CONSTANT: u64 = 1_000_000_000_000;
-const MIN_FARMING_EPOCHS: u8 = 2;
+const MIN_FARMING_EPOCHS: u64 = 2;
 const PENALTY_PERCENT: u64 = 10;
 
 #[allow(dead_code)] // owner_address is unused, at least for now
@@ -65,6 +65,7 @@ where
                 farming_token_id,
                 division_safety_constant,
                 pair_address,
+                MultiValueEncoded::new(),
             );
 
             let farm_token_id = managed_token_id!(FARM_TOKEN_ID);

--- a/dex/tests/farm_rs_test.rs
+++ b/dex/tests/farm_rs_test.rs
@@ -1,6 +1,6 @@
 use common_structs::FarmTokenAttributes;
 use elrond_wasm::storage::mappers::StorageTokenWrapper;
-use elrond_wasm::types::{Address, EsdtLocalRole, EsdtTokenPayment};
+use elrond_wasm::types::{Address, EsdtLocalRole, EsdtTokenPayment, MultiValueEncoded};
 use elrond_wasm_debug::tx_mock::{TxContextStack, TxInputESDT};
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_token_id, rust_biguint, testing_framework::*,
@@ -25,7 +25,7 @@ const LP_TOKEN_ID: &[u8] = b"LPTOK-abcdef"; // farming token ID
 const FARM_TOKEN_ID: &[u8] = b"FARM-abcdef";
 const OLD_FARM_TOKEN_ID: &[u8] = b"OFARM-abcdef";
 const DIVISION_SAFETY_CONSTANT: u64 = 1_000_000_000_000;
-const MIN_FARMING_EPOCHS: u8 = 2;
+const MIN_FARMING_EPOCHS: u64 = 2;
 const PENALTY_PERCENT: u64 = 10;
 const PER_BLOCK_REWARD_AMOUNT: u64 = 5_000;
 
@@ -70,6 +70,7 @@ where
                 farming_token_id,
                 division_safety_constant,
                 pair_address,
+                MultiValueEncoded::new(),
             );
 
             let farm_token_id = managed_token_id!(FARM_TOKEN_ID);
@@ -77,8 +78,8 @@ where
 
             sc.per_block_reward_amount()
                 .set(&managed_biguint!(PER_BLOCK_REWARD_AMOUNT));
-            sc.minimum_farming_epochs().set(&MIN_FARMING_EPOCHS);
-            sc.penalty_percent().set(&PENALTY_PERCENT);
+            sc.minimum_farming_epochs().set(MIN_FARMING_EPOCHS);
+            sc.penalty_percent().set(PENALTY_PERCENT);
 
             sc.state().set(&State::Active);
             sc.produce_rewards_enabled().set(&true);

--- a/dex/tests/farm_with_lock_review_distribution.rs
+++ b/dex/tests/farm_with_lock_review_distribution.rs
@@ -32,7 +32,7 @@ const LKMEX_TOKEN_ID: &[u8] = b"LKMEX-abcdef";
 const LP_TOKEN_ID: &[u8] = b"LPTOK-abcdef"; // farming token ID
 const FARM_TOKEN_ID: &[u8] = b"FARM-abcdef";
 const DIVISION_SAFETY_CONSTANT: u64 = 1_000_000_000_000;
-const MIN_FARMING_EPOCHS: u8 = 2;
+const MIN_FARMING_EPOCHS: u64 = 2;
 const PENALTY_PERCENT: u64 = 10;
 
 #[allow(dead_code)] // owner_address is unused, at least for now

--- a/farm-staking/farm-staking-proxy/tests/constants/mod.rs
+++ b/farm-staking/farm-staking-proxy/tests/constants/mod.rs
@@ -18,7 +18,7 @@ pub const BLOCK_NONCE_AFTER_PAIR_SETUP: u64 = 100;
 pub const FARM_WASM_PATH: &'static str = "farm/output/farm.wasm";
 pub const LP_FARM_TOKEN_ID: &[u8] = b"LPFARM-abcdef";
 pub const DIVISION_SAFETY_CONSTANT: u64 = 1_000_000_000_000;
-pub const MIN_FARMING_EPOCHS: u8 = 2;
+pub const MIN_FARMING_EPOCHS: u64 = 2;
 pub const PENALTY_PERCENT: u64 = 10;
 pub const LP_FARM_PER_BLOCK_REWARD_AMOUNT: u64 = 5_000;
 

--- a/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_external_contracts/mod.rs
+++ b/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_external_contracts/mod.rs
@@ -1,6 +1,6 @@
 use elrond_wasm::elrond_codec::multi_types::{MultiValue3, OptionalValue};
 use elrond_wasm::storage::mappers::StorageTokenWrapper;
-use elrond_wasm::types::{Address, EsdtLocalRole};
+use elrond_wasm::types::{Address, EsdtLocalRole, MultiValueEncoded};
 use elrond_wasm_debug::tx_mock::TxInputESDT;
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_token_id, rust_biguint, testing_framework::*,
@@ -220,12 +220,13 @@ where
                 farming_token_id,
                 division_safety_constant,
                 pair_address,
+                MultiValueEncoded::new(),
             );
 
             let farm_token_id = managed_token_id!(LP_FARM_TOKEN_ID);
             sc.farm_token().set_token_id(&farm_token_id);
 
-            sc.minimum_farming_epochs().set(&MIN_FARMING_EPOCHS);
+            sc.minimum_farming_epochs().set(MIN_FARMING_EPOCHS);
             sc.penalty_percent().set(&PENALTY_PERCENT);
 
             sc.state().set(&State::Active);

--- a/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_setup/mod.rs
+++ b/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_setup/mod.rs
@@ -1,5 +1,5 @@
 use elrond_wasm::storage::mappers::StorageTokenWrapper;
-use elrond_wasm::types::{Address, EsdtLocalRole};
+use elrond_wasm::types::{Address, EsdtLocalRole, MultiValueEncoded};
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_token_id, rust_biguint,
     testing_framework::{BlockchainStateWrapper, ContractObjWrapper},
@@ -37,7 +37,13 @@ where
             let div_const = managed_biguint!(DIVISION_SAFETY_CONSTANT);
             let max_apr = managed_biguint!(MAX_APR);
 
-            sc.init(farming_token_id, div_const, max_apr, UNBOND_EPOCHS);
+            sc.init(
+                farming_token_id,
+                div_const,
+                max_apr,
+                UNBOND_EPOCHS,
+                MultiValueEncoded::new(),
+            );
 
             sc.farm_token()
                 .set_token_id(&managed_token_id!(STAKING_FARM_TOKEN_ID));

--- a/farm-staking/farm-staking/Cargo.toml
+++ b/farm-staking/farm-staking/Cargo.toml
@@ -26,6 +26,9 @@ path = "../../common/modules/token_merge"
 [dependencies.pausable]
 path = "../../common/modules/pausable"
 
+[dependencies.admin_whitelist]
+path = "../../common/modules/admin_whitelist"
+
 [dependencies.factory]
 path = "../../locked-asset/factory"
 

--- a/farm-staking/farm-staking/src/farm_token_merge.rs
+++ b/farm-staking/farm-staking/src/farm_token_merge.rs
@@ -33,6 +33,7 @@ pub trait FarmTokenMergeModule:
     + config::ConfigModule
     + token_merge::TokenMergeModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     #[payable("*")]

--- a/farm-staking/farm-staking/src/lib.rs
+++ b/farm-staking/farm-staking/src/lib.rs
@@ -40,6 +40,7 @@ pub trait Farm:
     + farm_token_merge::FarmTokenMergeModule
     + whitelist::WhitelistModule
     + pausable::PausableModule
+    + admin_whitelist::AdminWhitelistModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     #[proxy]
@@ -52,6 +53,7 @@ pub trait Farm:
         division_safety_constant: BigUint,
         max_apr: BigUint,
         min_unbond_epochs: u64,
+        mut admins: MultiValueEncoded<ManagedAddress>,
     ) {
         require!(
             farming_token_id.is_valid_esdt_identifier(),
@@ -80,10 +82,15 @@ pub trait Farm:
         self.reward_token_id().set(&farming_token_id);
         self.farming_token_id().set(&farming_token_id);
         self.max_annual_percentage_rewards().set(&max_apr);
-        self.min_unbond_epochs().set(min_unbond_epochs);
+        self.try_set_min_unbond_epochs(min_unbond_epochs);
 
         let caller = self.blockchain().get_caller();
         self.pause_whitelist().add(&caller);
+
+        if admins.is_empty() {
+            admins.push(caller);
+        }
+        self.add_admins(admins);
     }
 
     #[payable("*")]

--- a/farm-staking/farm-staking/tests/farm_staking_test.rs
+++ b/farm-staking/farm-staking/tests/farm_staking_test.rs
@@ -1,5 +1,5 @@
 use elrond_wasm::storage::mappers::StorageTokenWrapper;
-use elrond_wasm::types::{Address, EsdtLocalRole};
+use elrond_wasm::types::{Address, EsdtLocalRole, MultiValueEncoded};
 use elrond_wasm_debug::tx_mock::{TxContextStack, TxInputESDT};
 use elrond_wasm_debug::{
     managed_biguint, managed_token_id, rust_biguint, testing_framework::*, DebugApi,
@@ -20,7 +20,7 @@ const REWARD_TOKEN_ID: &[u8] = b"RIDE-abcdef"; // reward token ID
 const FARMING_TOKEN_ID: &[u8] = b"RIDE-abcdef"; // farming token ID
 const FARM_TOKEN_ID: &[u8] = b"FARM-abcdef";
 const DIVISION_SAFETY_CONSTANT: u64 = 1_000_000_000_000;
-const MIN_FARMING_EPOCHS: u8 = 2;
+const MIN_FARMING_EPOCHS: u64 = 2;
 const MIN_UNBOND_EPOCHS: u64 = 5;
 const PENALTY_PERCENT: u64 = 10;
 const MAX_APR: u64 = 2_500; // 25%
@@ -66,6 +66,7 @@ where
                 division_safety_constant,
                 managed_biguint!(MAX_APR),
                 MIN_UNBOND_EPOCHS,
+                MultiValueEncoded::new(),
             );
 
             let farm_token_id = managed_token_id!(FARM_TOKEN_ID);
@@ -73,7 +74,7 @@ where
 
             sc.per_block_reward_amount()
                 .set(&managed_biguint!(PER_BLOCK_REWARD_AMOUNT));
-            sc.minimum_farming_epochs().set(&MIN_FARMING_EPOCHS);
+            sc.minimum_farming_epochs().set(MIN_FARMING_EPOCHS);
             sc.penalty_percent().set(&PENALTY_PERCENT);
 
             sc.state().set(&State::Active);

--- a/integration-test-lib/src/proxy.rs
+++ b/integration-test-lib/src/proxy.rs
@@ -2,7 +2,7 @@
 pub mod migration_tests {
     use elrond_wasm::elrond_codec::Empty;
     use elrond_wasm::storage::mappers::StorageTokenWrapper;
-    use elrond_wasm::types::{Address, EsdtLocalRole};
+    use elrond_wasm::types::{Address, EsdtLocalRole, MultiValueEncoded};
     use elrond_wasm_debug::tx_mock::TxContextStack;
     use elrond_wasm_debug::{
         managed_address, managed_biguint, managed_token_id, rust_biguint, testing_framework::*,
@@ -92,6 +92,7 @@ pub mod migration_tests {
                     managed_token_id!(LP_TOKEN_ID),
                     managed_biguint!(DIVISION_SAFETY_CONSTANT),
                     managed_address!(&Address::zero()),
+                    MultiValueEncoded::new(),
                 );
             })
             .assert_ok();

--- a/pause-all/tests/pause_all_test.rs
+++ b/pause-all/tests/pause_all_test.rs
@@ -51,6 +51,7 @@ fn pause_all_test() {
                 managed_token_id!(FARMING_TOKEN_ID),
                 managed_biguint!(DIV_SAFETY),
                 managed_address!(pair_sc.address_ref()),
+                MultiValueEncoded::new(),
             );
 
             sc.pause_whitelist()


### PR DESCRIPTION
Split actions on farm contracts based on who can call them:
- owner (or proxy contract)
- admin
- both

Also made it so the contracts still work the same as they do now if no admin is provided. (the owner is added as the single admin)