### PR TITLE
Locked token migration

### DIFF
--- a/dex/Cargo.toml
+++ b/dex/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [dependencies.elrond-wasm]
 version = "0.34.0"
 
+[dev-dependencies.elrond-wasm-modules]
+version = "0.34.0"
+
 [dev-dependencies.elrond-wasm-debug]
 version = "0.34.0"
 

--- a/dex/tests/farm_with_lock_review_distribution.rs
+++ b/dex/tests/farm_with_lock_review_distribution.rs
@@ -13,6 +13,7 @@ use elrond_wasm_debug::{
     tx_mock::{TxContextStack, TxInputESDT},
     DebugApi,
 };
+use elrond_wasm_modules::pause::PauseModule;
 type RustBigUint = num_bigint::BigUint;
 
 use config::*;
@@ -80,6 +81,7 @@ where
             sc.init(asset_token_id.clone(), default_unlock_period);
 
             sc.locked_asset_token().set_token_id(&asset_token_id);
+            sc.set_paused(false);
         })
         .assert_ok();
 

--- a/locked-asset/factory/src/migration.rs
+++ b/locked-asset/factory/src/migration.rs
@@ -73,6 +73,7 @@ pub trait LockedTokenMigrationModule:
 
         let locked_token_id = self.locked_asset_token().get_token_id();
         let last_valid_token_nonce = self.migration_stop_token_nonce().get();
+        require!(last_valid_token_nonce > 0, "Migration not started yet");
 
         let mut total_locked_tokens = BigUint::zero();
         let mut args = MultiValueEncoded::new();

--- a/locked-asset/factory/src/migration.rs
+++ b/locked-asset/factory/src/migration.rs
@@ -1,0 +1,131 @@
+elrond_wasm::imports!();
+
+use common_structs::{Epoch, Nonce};
+
+mod simple_lock_energy_proxy {
+    elrond_wasm::imports!();
+
+    use common_structs::Epoch;
+
+    #[elrond_wasm::proxy]
+    pub trait SimpleLockEnergyProxy {
+        #[payable("*")]
+        #[endpoint(acceptMigratedTokens)]
+        fn accept_migrated_tokens(
+            &self,
+            original_caller: ManagedAddress,
+            amount_unlock_epoch_pairs: MultiValueEncoded<MultiValue2<BigUint, Epoch>>,
+        ) -> ManagedVec<EsdtTokenPayment<Self::Api>>;
+    }
+}
+
+#[elrond_wasm::module]
+pub trait LockedTokenMigrationModule:
+    crate::locked_asset::LockedAssetModule
+    + token_send::TokenSendModule
+    + crate::attr_ex_helper::AttrExHelper
+    + elrond_wasm_modules::pause::PauseModule
+{
+    /// This endpoint allows migration to the new SC to start, which in turn:
+    /// - sets the address of the new factory, which should be a SimpleLockEnergy SC
+    /// - saves the current locked token NFT nonce, to detect old vs new tokens
+    /// - pauses locked asset factory
+    ///
+    /// Once started, migration may not be stopped nor started again
+    #[only_owner]
+    #[endpoint(startMigration)]
+    fn start_migration(&self, new_sc_address: ManagedAddress) {
+        require!(
+            self.new_contract_address().is_empty(),
+            "Migration already started"
+        );
+        require!(
+            self.blockchain().is_smart_contract(&new_sc_address),
+            "Invalid SC address"
+        );
+
+        self.new_contract_address().set(&new_sc_address);
+
+        let locked_token_id = self.locked_asset_token().get_token_id();
+        let own_sc_address = self.blockchain().get_sc_address();
+        let current_locked_token_nonce = self
+            .blockchain()
+            .get_current_esdt_nft_nonce(&own_sc_address, &locked_token_id);
+        self.migration_stop_token_nonce()
+            .set(current_locked_token_nonce);
+
+        self.set_paused(true);
+    }
+
+    /// Facilitates migrating of old locked tokens to the new contract.
+    ///
+    /// Expected input payments: Any number of locked tokens
+    ///
+    /// Output payments: New version of the locked tokens.
+    /// The new tokens may be used in the new contract, which can be queried via getNewContractAddress
+    #[payable("*")]
+    #[endpoint(migrateToNewFactory)]
+    fn migrate_to_new_factory(&self) -> ManagedVec<EsdtTokenPayment<Self::Api>> {
+        self.require_paused();
+
+        let payments = self.call_value().all_esdt_transfers();
+        require!(!payments.is_empty(), "No payments");
+
+        let locked_token_id = self.locked_asset_token().get_token_id();
+        let last_valid_token_nonce = self.migration_stop_token_nonce().get();
+
+        let mut total_locked_tokens = BigUint::zero();
+        let mut args = MultiValueEncoded::new();
+        for payment in &payments {
+            require!(payment.token_identifier == locked_token_id, "Invalid token");
+            require!(
+                payment.token_nonce <= last_valid_token_nonce,
+                "Token already migrated"
+            );
+
+            let attributes = self.get_attributes_ex(&payment.token_identifier, payment.token_nonce);
+            let unlock_amounts = self.get_unlock_amounts_per_milestone(
+                &attributes.unlock_schedule.unlock_milestones,
+                &payment.amount,
+            );
+            for pair in unlock_amounts {
+                if pair.amount > 0 {
+                    args.push((pair.amount, pair.epoch).into());
+                }
+            }
+
+            total_locked_tokens += payment.amount;
+        }
+
+        self.migrate_tokens(total_locked_tokens, args)
+    }
+
+    fn migrate_tokens(
+        &self,
+        total_base_asset_amount: BigUint,
+        arg_pairs: MultiValueEncoded<MultiValue2<BigUint, Epoch>>,
+    ) -> ManagedVec<EsdtTokenPayment<Self::Api>> {
+        let original_caller = self.blockchain().get_caller();
+        let base_asset_token_id = self.asset_token_id().get();
+        let sc_address = self.new_contract_address().get();
+
+        self.simple_lock_energy_proxy_builder(sc_address)
+            .accept_migrated_tokens(original_caller, arg_pairs)
+            .add_esdt_token_transfer(base_asset_token_id, 0, total_base_asset_amount)
+            .execute_on_dest_context()
+    }
+
+    #[proxy]
+    fn simple_lock_energy_proxy_builder(
+        &self,
+        sc_address: ManagedAddress,
+    ) -> simple_lock_energy_proxy::Proxy<Self::Api>;
+
+    #[view(getNewContractAddress)]
+    #[storage_mapper("newContractAddress")]
+    fn new_contract_address(&self) -> SingleValueMapper<ManagedAddress>;
+
+    #[view(getMigrationStopTokenNonce)]
+    #[storage_mapper("migrationStopTokenNonce")]
+    fn migration_stop_token_nonce(&self) -> SingleValueMapper<Nonce>;
+}

--- a/locked-asset/factory/src/migration.rs
+++ b/locked-asset/factory/src/migration.rs
@@ -94,6 +94,12 @@ pub trait LockedTokenMigrationModule:
                 }
             }
 
+            self.send().esdt_local_burn(
+                &payment.token_identifier,
+                payment.token_nonce,
+                &payment.amount,
+            );
+
             total_locked_tokens += payment.amount;
         }
 

--- a/locked-asset/factory/tests/lock_test.rs
+++ b/locked-asset/factory/tests/lock_test.rs
@@ -11,6 +11,7 @@ use elrond_wasm_debug::{
 
 const SC_WASM_PATH: &'static str = "output/factory.wasm";
 
+use elrond_wasm_modules::pause::PauseModule;
 use factory::{locked_asset::LockedAssetModule, LockedAssetFactory};
 
 const ASSET_TOKEN_ID: &[u8] = b"MEX-123456";
@@ -39,6 +40,7 @@ fn test_lock_assets() {
             sc.init(asset_token_id, unlock_period);
             sc.locked_asset_token()
                 .set_token_id(&managed_token_id!(LOCKED_ASSET_TOKEN_ID));
+            sc.set_paused(false);
         })
         .assert_ok();
 

--- a/locked-asset/factory/wasm/src/lib.rs
+++ b/locked-asset/factory/wasm/src/lib.rs
@@ -8,26 +8,30 @@ elrond_wasm_node::wasm_endpoints! {
     factory
     (
         callBack
-        computeEnergyForOldLockedTokens
         createAndForward
         createAndForwardCustomPeriod
         getAssetTokenId
         getCacheSize
         getDefaultUnlockPeriod
-        getEnergyAmountForUser
-        getEnergyEntryForUser
         getExtendedAttributesActivationNonce
         getInitEpoch
         getLockedAssetTokenId
+        getMigrationStopTokenNonce
+        getNewContractAddress
         getUnlockScheduleForSFTNonce
         getWhitelistedContracts
+        isPaused
         lockAssets
         mergeLockedAssetTokens
+        migrateToNewFactory
+        pause
         registerLockedAssetToken
         removeWhitelist
         setInitEpoch
         setUnlockPeriod
+        startMigration
         unlockAssets
+        unpause
         whitelist
     )
 }

--- a/locked-asset/mandos/steps/deploy.steps.json
+++ b/locked-asset/mandos/steps/deploy.steps.json
@@ -135,6 +135,25 @@
             }
         },
         {
+            "step": "scCall",
+            "txId": "unpause",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:locked_asset_factory",
+                "value": "0",
+                "function": "unpause",
+                "arguments": [],
+                "gasLimit": "100,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": "*",
+                "status": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
             "step": "scDeploy",
             "txId": "1",
             "tx": {

--- a/locked-asset/simple-lock-energy/src/migration.rs
+++ b/locked-asset/simple-lock-energy/src/migration.rs
@@ -1,0 +1,108 @@
+elrond_wasm::imports!();
+
+use common_structs::Epoch;
+
+#[elrond_wasm::module]
+pub trait SimpleLockMigrationModule:
+    simple_lock::basic_lock_unlock::BasicLockUnlock
+    + simple_lock::locked_token::LockedTokenModule
+    + simple_lock::token_attributes::TokenAttributesModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
+    + crate::token_whitelist::TokenWhitelistModule
+    + crate::util::UtilModule
+{
+    /// Sets the address for the contract which is expected to perform the migration
+    #[only_owner]
+    #[endpoint(setOldLockedAssetFactoryAddress)]
+    fn set_old_locked_asset_factory_address(&self, old_sc_address: ManagedAddress) {
+        require!(
+            self.old_locked_asset_factory_address().is_empty(),
+            "Migration already started"
+        );
+        require!(
+            self.blockchain().is_smart_contract(&old_sc_address),
+            "Invalid SC address"
+        );
+
+        self.old_locked_asset_factory_address().set(&old_sc_address);
+    }
+
+    /// Converts old tokens from the locked asset factory into the new version.
+    /// Additionally, it also updates the user's energy accordingly.
+    ///
+    /// This endpoint can only be called through the "migrateToNewFactory" endpoint
+    /// from locked asset factory, and may not be called directly
+    ///
+    /// Expect input payment: total base assets locked under the given positions
+    ///
+    /// Expected arguments:
+    /// - original_caller: the caller from the "migrateToNewFactory" call
+    /// - amount_unlock_epoch_pairs: constructed from the original attributes
+    /// by locked asset factory. Each milestone entry will generate a different token
+    ///
+    /// Output payments: New version of the locked tokens
+    #[payable("*")]
+    #[endpoint(acceptMigratedTokens)]
+    fn accept_migrated_tokens(
+        &self,
+        original_caller: ManagedAddress,
+        amount_unlock_epoch_pairs: MultiValueEncoded<MultiValue2<BigUint, Epoch>>,
+    ) -> ManagedVec<EsdtTokenPayment<Self::Api>> {
+        let caller = self.blockchain().get_caller();
+        self.require_old_sc_address(&caller);
+
+        let payment = self.call_value().single_esdt();
+        self.require_is_base_asset_token(&payment.token_identifier);
+
+        let base_asset_token_id = self.base_asset_token_id().get();
+        let current_epoch = self.blockchain().get_block_epoch();
+
+        let mut total_tokens_in_pairs = BigUint::zero();
+        let mut total_unlockable_tokens = BigUint::zero();
+        let mut output_payments = ManagedVec::new();
+        for pair in amount_unlock_epoch_pairs {
+            let (token_amount, unlock_epoch) = pair.into_tuple();
+            total_tokens_in_pairs += &token_amount;
+
+            if unlock_epoch > current_epoch {
+                let original_tokens = EgldOrEsdtTokenPayment::new(
+                    EgldOrEsdtTokenIdentifier::esdt(base_asset_token_id.clone()),
+                    0,
+                    token_amount,
+                );
+                let locked_tokens = self.lock_tokens(original_tokens, unlock_epoch);
+                output_payments.push(self.to_esdt_payment(locked_tokens));
+            } else {
+                total_unlockable_tokens += &token_amount;
+            }
+        }
+
+        require!(
+            payment.amount == total_tokens_in_pairs,
+            "Total amount mismatch"
+        );
+
+        if total_unlockable_tokens > 0 {
+            let unlockable_tokens_payment =
+                EsdtTokenPayment::new(base_asset_token_id, 0, total_unlockable_tokens);
+            output_payments.push(unlockable_tokens_payment);
+        }
+
+        if !output_payments.is_empty() {
+            self.send().direct_multi(&original_caller, &output_payments);
+        }
+
+        output_payments
+    }
+
+    fn require_old_sc_address(&self, address: &ManagedAddress) {
+        let mapper = self.old_locked_asset_factory_address();
+        require!(!mapper.is_empty(), "old SC address not set");
+
+        let sc_address = mapper.get();
+        require!(address == &sc_address, "Invalid SC address");
+    }
+
+    #[storage_mapper("oldLockedAssetFactoryAddress")]
+    fn old_locked_asset_factory_address(&self) -> SingleValueMapper<ManagedAddress>;
+}

--- a/locked-asset/simple-lock-energy/src/util.rs
+++ b/locked-asset/simple-lock-energy/src/util.rs
@@ -1,0 +1,22 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait UtilModule {
+    fn dest_from_optional(&self, opt_destination: OptionalValue<ManagedAddress>) -> ManagedAddress {
+        match opt_destination {
+            OptionalValue::Some(dest) => dest,
+            OptionalValue::None => self.blockchain().get_caller(),
+        }
+    }
+
+    fn to_esdt_payment(
+        &self,
+        egld_or_esdt_payment: EgldOrEsdtTokenPayment<Self::Api>,
+    ) -> EsdtTokenPayment<Self::Api> {
+        EsdtTokenPayment::new(
+            egld_or_esdt_payment.token_identifier.unwrap_esdt(),
+            egld_or_esdt_payment.token_nonce,
+            egld_or_esdt_payment.amount,
+        )
+    }
+}

--- a/locked-asset/simple-lock-energy/wasm/src/lib.rs
+++ b/locked-asset/simple-lock-energy/wasm/src/lib.rs
@@ -8,6 +8,7 @@ elrond_wasm_node::wasm_endpoints! {
     simple_lock_energy
     (
         callBack
+        acceptMigratedTokens
         addLockOptions
         getBaseAssetTokenId
         getEnergyAmountForUser
@@ -18,6 +19,7 @@ elrond_wasm_node::wasm_endpoints! {
         lockTokens
         removeLockOptions
         setLockedTokenId
+        setOldLockedAssetFactoryAddress
         unlockTokens
     )
 }


### PR DESCRIPTION
Flow:
- user calls `migrateToNewFactory` in `factory`
- `factory` calculates the amounts per epoch, and forwards the base asset (unlocked funds) +  the calculated unlock amounts per epoch
- `simple lock` creates the new tokens, and also automatically unlocks tokens that are past unlock epoch already