### PR TITLE
changed permissions for penalty params endpoints

### DIFF
--- a/common/modules/farm/config/src/config.rs
+++ b/common/modules/farm/config/src/config.rs
@@ -26,20 +26,20 @@ pub trait ConfigModule:
         state == State::Active
     }
 
-    #[only_admin]
+    #[only_owner]
     #[endpoint]
     fn set_penalty_percent(&self, percent: u64) {
         require!(percent < MAX_PERCENT, ERROR_PARAMETERS);
         self.penalty_percent().set(&percent);
     }
 
-    #[only_admin]
+    #[only_owner]
     #[endpoint]
     fn set_minimum_farming_epochs(&self, epochs: u8) {
         self.minimum_farming_epochs().set(&epochs);
     }
 
-    #[only_admin]
+    #[only_owner]
     #[endpoint]
     fn set_burn_gas_limit(&self, gas_limit: u64) {
         self.burn_gas_limit().set(&gas_limit);


### PR DESCRIPTION
Changed permissions for the endpoints altering penalty parameters in order to avoid abuses from contract admins leading to possible locking of tokens into the farm contracts.
At this point, these endpoints have no limits for the parameters. If admin has unfettered access to these, they can wait until community enters the farm then modify the minimum epochs value to a huge value and jack up the penalty to 100% leading to any farm position to be either blocked in farm or risk burning the entire position at exit.