### PR TITLE
simple lock own token

### DIFF
--- a/locked-asset/simple-lock-energy/src/lib.rs
+++ b/locked-asset/simple-lock-energy/src/lib.rs
@@ -111,8 +111,6 @@ pub trait SimpleLockEnergy:
         self.require_not_paused();
 
         let payment = self.call_value().single_esdt();
-        self.require_is_new_token(payment.token_nonce);
-
         let attributes: LockedTokenAttributes<Self::Api> = self
             .locked_token()
             .get_token_attributes(payment.token_nonce);

--- a/locked-asset/simple-lock-energy/src/migration.rs
+++ b/locked-asset/simple-lock-energy/src/migration.rs
@@ -1,6 +1,6 @@
 elrond_wasm::imports!();
 
-use common_structs::{Epoch, Nonce};
+use common_structs::Epoch;
 
 #[elrond_wasm::module]
 pub trait SimpleLockMigrationModule:
@@ -13,42 +13,10 @@ pub trait SimpleLockMigrationModule:
     + crate::energy::EnergyModule
     + elrond_wasm_modules::pause::PauseModule
 {
-    /// Sets the LOCKED token ID. This is required, since we use an already existing token,
-    /// instead of issue-ing a new one.
-    ///
-    /// The SC must already have the following roles before this function can be called:
-    /// - NFTCReate
-    /// - NFTAddQuantity
-    /// - NFTBurn
-    /// - TransferRole
-    #[only_owner]
-    #[endpoint(setLockedTokenId)]
-    fn set_locked_token_id(&self, token_id: TokenIdentifier) {
-        self.require_paused();
-        self.require_valid_token_id(&token_id);
-        self.require_has_roles_for_locked_token(&token_id);
-
-        let own_sc_address = self.blockchain().get_sc_address();
-        let last_old_token_nonce = self
-            .blockchain()
-            .get_current_esdt_nft_nonce(&own_sc_address, &token_id);
-        let new_token_start_nonce = last_old_token_nonce + 1;
-
-        self.new_token_start_nonce().set(new_token_start_nonce);
-        self.locked_token().set_token_id(&token_id);
-    }
-
-    fn require_has_roles_for_locked_token(&self, token_id: &TokenIdentifier) {
-        let actual_roles = self.blockchain().get_esdt_local_roles(token_id);
-        let required_roles = EsdtLocalRoleFlags::NFT_CREATE
-            | EsdtLocalRoleFlags::NFT_ADD_QUANTITY
-            | EsdtLocalRoleFlags::NFT_BURN
-            | EsdtLocalRoleFlags::TRANSFER;
-        require!(
-            actual_roles.contains(required_roles),
-            "SC does not have ESDT transfer role for {}",
-            token_id
-        );
+    #[endpoint(setTransferRoleLockedToken)]
+    fn set_transfer_role(&self) {
+        self.locked_token()
+            .set_local_roles(&[EsdtLocalRole::Transfer], None);
     }
 
     /// Sets the address for the contract which is expected to perform the migration
@@ -151,17 +119,6 @@ pub trait SimpleLockMigrationModule:
         require!(address == &sc_address, "Invalid SC address");
     }
 
-    fn require_is_new_token(&self, token_nonce: Nonce) {
-        let new_token_start_nonce = self.new_token_start_nonce().get();
-        require!(
-            token_nonce >= new_token_start_nonce,
-            "Old tokens not allowed"
-        );
-    }
-
     #[storage_mapper("oldLockedAssetFactoryAddress")]
     fn old_locked_asset_factory_address(&self) -> SingleValueMapper<ManagedAddress>;
-
-    #[storage_mapper("newTokenStartNonce")]
-    fn new_token_start_nonce(&self) -> SingleValueMapper<Nonce>;
 }

--- a/locked-asset/simple-lock-energy/src/unlock_with_penalty.rs
+++ b/locked-asset/simple-lock-energy/src/unlock_with_penalty.rs
@@ -98,8 +98,6 @@ pub trait UnlockWithPenaltyModule:
         self.require_not_paused();
 
         let payment = self.call_value().single_esdt();
-        self.require_is_new_token(payment.token_nonce);
-
         let attributes: LockedTokenAttributes<Self::Api> = self
             .locked_token()
             .get_token_attributes(payment.token_nonce);

--- a/locked-asset/simple-lock-energy/wasm/src/lib.rs
+++ b/locked-asset/simple-lock-energy/wasm/src/lib.rs
@@ -24,9 +24,9 @@ elrond_wasm_node::wasm_endpoints! {
         removeLockOptions
         setFeesBurnPercentage
         setFeesCollectorAddress
-        setLockedTokenId
         setOldLockedAssetFactoryAddress
         setPenaltyPercentage
+        setTransferRoleLockedToken
         unlockEarly
         unlockTokens
         unpause


### PR DESCRIPTION
- simple-lock-energy now uses its own token, which is created through the issue function, instead of expecting a manual setting of the token ID