### PR TITLE
Extend lock period

### DIFF
--- a/locked-asset/simple-lock-energy/src/energy.rs
+++ b/locked-asset/simple-lock-energy/src/energy.rs
@@ -90,6 +90,16 @@ impl<M: ManagedTypeApi> Energy<M> {
         self.total_locked_tokens -= unlock_amount;
     }
 
+    pub fn deplete_after_early_unlock(
+        &mut self,
+        unlock_amount: &BigUint<M>,
+        unlock_epoch: Epoch,
+        current_epoch: Epoch,
+    ) {
+        self.subtract(unlock_epoch, current_epoch, unlock_amount);
+        self.total_locked_tokens -= unlock_amount;
+    }
+
     #[inline]
     pub fn get_last_update_epoch(&self) -> Epoch {
         self.last_update_epoch
@@ -132,7 +142,11 @@ pub trait EnergyModule {
     ) {
         let current_epoch = self.blockchain().get_block_epoch();
         let mut energy = self.get_updated_energy_entry_for_user(user, current_epoch);
-        energy.refund_after_token_unlock(old_locked_token_amount, unlock_epoch, current_epoch);
+        if unlock_epoch <= current_epoch {
+            energy.refund_after_token_unlock(old_locked_token_amount, unlock_epoch, current_epoch);
+        } else {
+            energy.deplete_after_early_unlock(old_locked_token_amount, unlock_epoch, current_epoch);
+        }
 
         self.user_energy(user).set(&energy);
     }

--- a/locked-asset/simple-lock-energy/src/energy.rs
+++ b/locked-asset/simple-lock-energy/src/energy.rs
@@ -96,7 +96,7 @@ impl<M: ManagedTypeApi> Energy<M> {
         unlock_epoch: Epoch,
         current_epoch: Epoch,
     ) {
-        self.subtract(unlock_epoch, current_epoch, unlock_amount);
+        self.subtract(current_epoch, unlock_epoch, unlock_amount);
         self.total_locked_tokens -= unlock_amount;
     }
 

--- a/locked-asset/simple-lock-energy/src/extend_lock.rs
+++ b/locked-asset/simple-lock-energy/src/extend_lock.rs
@@ -1,0 +1,49 @@
+elrond_wasm::imports!();
+
+use common_structs::Epoch;
+use simple_lock::locked_token::LockedTokenAttributes;
+
+#[elrond_wasm::module]
+pub trait ExtendLockModule:
+    simple_lock::basic_lock_unlock::BasicLockUnlock
+    + simple_lock::locked_token::LockedTokenModule
+    + simple_lock::token_attributes::TokenAttributesModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
+    + crate::token_whitelist::TokenWhitelistModule
+    + crate::util::UtilModule
+    + crate::energy::EnergyModule
+    + crate::migration::SimpleLockMigrationModule
+    + crate::lock_options::LockOptionsModule
+    + elrond_wasm_modules::pause::PauseModule
+{
+    /// Extend locking period of a previously locked token.
+    /// new_lock_period must still be one of the available options.
+    /// No penalty is received for performing this action.
+    #[payable("*")]
+    #[endpoint(extendLockingPeriod)]
+    fn extend_locking_period(&self, new_lock_period: Epoch) -> EsdtTokenPayment {
+        self.require_not_paused();
+        self.require_is_listed_lock_option(new_lock_period);
+
+        let payment = self.call_value().single_esdt();
+        let attributes: LockedTokenAttributes<Self::Api> = self
+            .locked_token()
+            .get_token_attributes(payment.token_nonce);
+
+        let current_epoch = self.blockchain().get_block_epoch();
+        let new_unlock_epoch = current_epoch + new_lock_period;
+        require!(
+            new_unlock_epoch > attributes.unlock_epoch,
+            "New lock period must be lomger than the current one."
+        );
+
+        let caller = self.blockchain().get_caller();
+        self.update_energy_after_unlock(&caller, &payment.amount, attributes.unlock_epoch);
+        self.update_energy_after_lock(&caller, &payment.amount, new_unlock_epoch);
+
+        let unlocked_tokens = self.unlock_tokens_unchecked(payment, &attributes);
+        let output_payment = self.lock_and_send(&caller, unlocked_tokens, new_unlock_epoch);
+
+        self.to_esdt_payment(output_payment)
+    }
+}

--- a/locked-asset/simple-lock-energy/src/extend_lock.rs
+++ b/locked-asset/simple-lock-energy/src/extend_lock.rs
@@ -34,7 +34,7 @@ pub trait ExtendLockModule:
         let new_unlock_epoch = current_epoch + new_lock_period;
         require!(
             new_unlock_epoch > attributes.unlock_epoch,
-            "New lock period must be lomger than the current one."
+            "New lock period must be longer than the current one."
         );
 
         let caller = self.blockchain().get_caller();

--- a/locked-asset/simple-lock-energy/src/lib.rs
+++ b/locked-asset/simple-lock-energy/src/lib.rs
@@ -3,6 +3,7 @@
 elrond_wasm::imports!();
 
 pub mod energy;
+pub mod extend_lock;
 pub mod lock_options;
 pub mod migration;
 pub mod token_whitelist;
@@ -22,12 +23,13 @@ pub trait SimpleLockEnergy:
     + energy::EnergyModule
     + lock_options::LockOptionsModule
     + unlock_with_penalty::UnlockWithPenaltyModule
+    + extend_lock::ExtendLockModule
     + util::UtilModule
     + migration::SimpleLockMigrationModule
     + elrond_wasm_modules::pause::PauseModule
 {
     /// Args:
-    /// - base_asset_token_id: The only token that is accepted for the lockTokens endpoint. 
+    /// - base_asset_token_id: The only token that is accepted for the lockTokens endpoint.
     ///     NOTE: The SC also needs the ESDTLocalBurn role for this token.
     /// - min_penalty_percentage / max_penalty_percentage: The penalty for early unlock
     ///     of a token. A token locked for the max period, will have max_penalty_percentage penalty,

--- a/locked-asset/simple-lock-energy/tests/simple_lock_energy_setup/mod.rs
+++ b/locked-asset/simple-lock-energy/tests/simple_lock_energy_setup/mod.rs
@@ -12,7 +12,7 @@ use elrond_wasm_debug::{
 use elrond_wasm_modules::pause::PauseModule;
 use simple_lock::locked_token::LockedTokenModule;
 use simple_lock_energy::{
-    energy::EnergyModule, lock_options::LockOptionsModule,
+    energy::EnergyModule, extend_lock::ExtendLockModule, lock_options::LockOptionsModule,
     unlock_with_penalty::UnlockWithPenaltyModule, SimpleLockEnergy,
 };
 
@@ -143,6 +143,25 @@ where
             &rust_biguint!(amount),
             |sc| {
                 sc.lock_tokens_endpoint(lock_epochs, OptionalValue::Some(managed_address!(caller)));
+            },
+        )
+    }
+
+    pub fn extend_locking_period(
+        &mut self,
+        caller: &Address,
+        token_nonce: u64,
+        amount: u64,
+        lock_epochs: u64,
+    ) -> TxResult {
+        self.b_mock.execute_esdt_transfer(
+            caller,
+            &self.sc_wrapper,
+            LOCKED_TOKEN_ID,
+            token_nonce,
+            &rust_biguint!(amount),
+            |sc| {
+                sc.extend_locking_period(lock_epochs);
             },
         )
     }

--- a/locked-asset/simple-lock-energy/tests/simple_lock_energy_test.rs
+++ b/locked-asset/simple-lock-energy/tests/simple_lock_energy_test.rs
@@ -283,5 +283,5 @@ fn extend_locking_period_test() {
     // try "extend" to 1 year
     setup
         .extend_locking_period(&first_user, 2, half_balance, LOCK_OPTIONS[0])
-        .assert_user_error("New lock period must be lomger than the current one.");
+        .assert_user_error("New lock period must be longer than the current one.");
 }

--- a/locked-asset/simple-lock-energy/tests/simple_lock_energy_test.rs
+++ b/locked-asset/simple-lock-energy/tests/simple_lock_energy_test.rs
@@ -164,6 +164,10 @@ fn unlock_early_test() {
     setup
         .b_mock
         .check_esdt_balance(&first_user, BASE_ASSET_TOKEN_ID, &expected_balance);
+
+    let expected_energy = rust_biguint!(0);
+    let actual_energy = setup.get_user_energy(&first_user);
+    assert_eq!(actual_energy, expected_energy);
 }
 
 #[test]
@@ -226,4 +230,9 @@ fn reduce_lock_period_test() {
         BASE_ASSET_TOKEN_ID,
         &(penalty_amount / 2u64),
     );
+
+    // check new energy amount
+    let expected_energy = rust_biguint!(half_year_epochs + 1) * expected_locked_token_balance;
+    let actual_energy = setup.get_user_energy(&first_user);
+    assert_eq!(actual_energy, expected_energy);
 }

--- a/locked-asset/simple-lock-energy/wasm/src/lib.rs
+++ b/locked-asset/simple-lock-energy/wasm/src/lib.rs
@@ -10,6 +10,7 @@ elrond_wasm_node::wasm_endpoints! {
         callBack
         acceptMigratedTokens
         addLockOptions
+        extendLockingPeriod
         getBaseAssetTokenId
         getEnergyAmountForUser
         getEnergyEntryForUser


### PR DESCRIPTION
- allow extending locking period of an already locked token
- fix a bug where energy would not be updated after early unlock/reduce locking period