### PR TITLE
Same locked nonce per unlock month

### DIFF
--- a/locked-asset/simple-lock-energy/src/extend_lock.rs
+++ b/locked-asset/simple-lock-energy/src/extend_lock.rs
@@ -31,7 +31,7 @@ pub trait ExtendLockModule:
             .get_token_attributes(payment.token_nonce);
 
         let current_epoch = self.blockchain().get_block_epoch();
-        let new_unlock_epoch = current_epoch + new_lock_period;
+        let new_unlock_epoch = self.lock_option_to_start_of_month(current_epoch + new_lock_period);
         require!(
             new_unlock_epoch > attributes.unlock_epoch,
             "New lock period must be longer than the current one."

--- a/locked-asset/simple-lock-energy/src/extend_lock.rs
+++ b/locked-asset/simple-lock-energy/src/extend_lock.rs
@@ -31,7 +31,7 @@ pub trait ExtendLockModule:
             .get_token_attributes(payment.token_nonce);
 
         let current_epoch = self.blockchain().get_block_epoch();
-        let new_unlock_epoch = self.lock_option_to_start_of_month(current_epoch + new_lock_period);
+        let new_unlock_epoch = self.lock_epoch_to_start_of_month(current_epoch + new_lock_period);
         require!(
             new_unlock_epoch > attributes.unlock_epoch,
             "New lock period must be longer than the current one."

--- a/locked-asset/simple-lock-energy/src/lib.rs
+++ b/locked-asset/simple-lock-energy/src/lib.rs
@@ -87,7 +87,7 @@ pub trait SimpleLockEnergy:
 
         self.require_is_listed_lock_option(lock_epochs);
         let current_epoch = self.blockchain().get_block_epoch();
-        let unlock_epoch = current_epoch + lock_epochs;
+        let unlock_epoch = self.lock_option_to_start_of_month(current_epoch + lock_epochs);
 
         let dest_address = self.dest_from_optional(opt_destination);
         let output_tokens = self.lock_and_send(&dest_address, payment.into(), unlock_epoch);

--- a/locked-asset/simple-lock-energy/src/lib.rs
+++ b/locked-asset/simple-lock-energy/src/lib.rs
@@ -87,7 +87,7 @@ pub trait SimpleLockEnergy:
 
         self.require_is_listed_lock_option(lock_epochs);
         let current_epoch = self.blockchain().get_block_epoch();
-        let unlock_epoch = self.lock_option_to_start_of_month(current_epoch + lock_epochs);
+        let unlock_epoch = self.lock_epoch_to_start_of_month(current_epoch + lock_epochs);
 
         let dest_address = self.dest_from_optional(opt_destination);
         let output_tokens = self.lock_and_send(&dest_address, payment.into(), unlock_epoch);

--- a/locked-asset/simple-lock-energy/src/lock_options.rs
+++ b/locked-asset/simple-lock-energy/src/lock_options.rs
@@ -70,7 +70,7 @@ pub trait LockOptionsModule {
         );
     }
 
-    fn lock_option_to_start_of_month(&self, lock_option: Epoch) -> Epoch {
+    fn lock_epoch_to_start_of_month(&self, lock_option: Epoch) -> Epoch {
         let extra_days = lock_option % EPOCHS_PER_MONTH;
         lock_option - extra_days
     }

--- a/locked-asset/simple-lock-energy/src/lock_options.rs
+++ b/locked-asset/simple-lock-energy/src/lock_options.rs
@@ -3,6 +3,8 @@ elrond_wasm::derive_imports!();
 
 use common_structs::Epoch;
 
+pub const EPOCHS_PER_MONTH: Epoch = 30;
+
 #[elrond_wasm::module]
 pub trait LockOptionsModule {
     /// Add lock options, as a list of epochs.
@@ -66,6 +68,11 @@ pub trait LockOptionsModule {
             self.lock_options().contains(&lock_epochs),
             "Invalid lock choice"
         );
+    }
+
+    fn lock_option_to_start_of_month(&self, lock_option: Epoch) -> Epoch {
+        let extra_days = lock_option % EPOCHS_PER_MONTH;
+        lock_option - extra_days
     }
 
     #[view(getLockOptions)]

--- a/locked-asset/simple-lock-energy/src/unlock_with_penalty.rs
+++ b/locked-asset/simple-lock-energy/src/unlock_with_penalty.rs
@@ -134,7 +134,7 @@ pub trait UnlockWithPenaltyModule:
         }
 
         let new_unlock_epoch =
-            self.lock_option_to_start_of_month(attributes.unlock_epoch - epochs_to_reduce);
+            self.lock_epoch_to_start_of_month(attributes.unlock_epoch - epochs_to_reduce);
         let output_payment = self.lock_and_send(&caller, unlocked_tokens, new_unlock_epoch);
         self.update_energy_after_lock(&caller, &output_payment.amount, new_unlock_epoch);
 

--- a/locked-asset/simple-lock-energy/tests/simple_lock_energy_setup/mod.rs
+++ b/locked-asset/simple-lock-energy/tests/simple_lock_energy_setup/mod.rs
@@ -244,3 +244,7 @@ where
 fn to_rust_biguint(managed_biguint: elrond_wasm::types::BigUint<DebugApi>) -> num_bigint::BigUint {
     num_bigint::BigUint::from_bytes_be(managed_biguint.to_bytes_be().as_slice())
 }
+
+pub fn to_start_of_month(unlock_epoch: u64) -> u64 {
+    unlock_epoch - unlock_epoch % 30
+}

--- a/locked-asset/simple-lock-energy/tests/simple_lock_energy_test.rs
+++ b/locked-asset/simple-lock-energy/tests/simple_lock_energy_test.rs
@@ -35,7 +35,8 @@ fn lock_ok() {
     let first_user = setup.first_user.clone();
     let half_balance = USER_BALANCE / 2;
 
-    setup.b_mock.set_block_epoch(1);
+    let mut current_epoch = 1;
+    setup.b_mock.set_block_epoch(current_epoch);
 
     setup
         .lock(
@@ -51,6 +52,8 @@ fn lock_ok() {
         BASE_ASSET_TOKEN_ID,
         &rust_biguint!(half_balance),
     );
+
+    let first_unlock_epoch = to_start_of_month(current_epoch + LOCK_OPTIONS[0]);
     setup.b_mock.check_nft_balance(
         &first_user,
         LOCKED_TOKEN_ID,
@@ -59,17 +62,19 @@ fn lock_ok() {
         Some(&LockedTokenAttributes::<DebugApi> {
             original_token_id: managed_token_id_wrapped!(BASE_ASSET_TOKEN_ID),
             original_token_nonce: 0,
-            unlock_epoch: 1 + LOCK_OPTIONS[0],
+            unlock_epoch: first_unlock_epoch,
         }),
     );
 
-    let mut expected_user_energy = rust_biguint!(half_balance) * LOCK_OPTIONS[0];
+    let mut expected_user_energy =
+        rust_biguint!(half_balance) * (first_unlock_epoch - current_epoch);
     let mut actual_user_energy = setup.get_user_energy(&first_user);
     assert_eq!(expected_user_energy, actual_user_energy);
 
     // check energy after half a year
     let half_year_epochs = EPOCHS_IN_YEAR / 2;
-    setup.b_mock.set_block_epoch(1 + half_year_epochs);
+    current_epoch += half_year_epochs;
+    setup.b_mock.set_block_epoch(current_epoch);
 
     expected_user_energy -= rust_biguint!(half_balance) * half_year_epochs;
     actual_user_energy = setup.get_user_energy(&first_user);
@@ -88,17 +93,8 @@ fn lock_ok() {
     setup
         .b_mock
         .check_esdt_balance(&first_user, BASE_ASSET_TOKEN_ID, &rust_biguint!(0));
-    setup.b_mock.check_nft_balance(
-        &first_user,
-        LOCKED_TOKEN_ID,
-        1,
-        &rust_biguint!(half_balance),
-        Some(&LockedTokenAttributes::<DebugApi> {
-            original_token_id: managed_token_id_wrapped!(BASE_ASSET_TOKEN_ID),
-            original_token_nonce: 0,
-            unlock_epoch: 1 + LOCK_OPTIONS[0],
-        }),
-    );
+
+    let second_unlock_epoch = to_start_of_month(current_epoch + LOCK_OPTIONS[0]);
     setup.b_mock.check_nft_balance(
         &first_user,
         LOCKED_TOKEN_ID,
@@ -107,11 +103,11 @@ fn lock_ok() {
         Some(&LockedTokenAttributes::<DebugApi> {
             original_token_id: managed_token_id_wrapped!(BASE_ASSET_TOKEN_ID),
             original_token_nonce: 0,
-            unlock_epoch: 1 + half_year_epochs + LOCK_OPTIONS[0],
+            unlock_epoch: second_unlock_epoch,
         }),
     );
 
-    expected_user_energy += rust_biguint!(half_balance) * (LOCK_OPTIONS[0]);
+    expected_user_energy += rust_biguint!(half_balance) * (second_unlock_epoch - current_epoch);
     actual_user_energy = setup.get_user_energy(&first_user);
     assert_eq!(expected_user_energy, actual_user_energy);
 
@@ -121,7 +117,8 @@ fn lock_ok() {
         .assert_user_error("Cannot unlock yet");
 
     // unlock first tokens
-    setup.b_mock.set_block_epoch(1 + LOCK_OPTIONS[0]);
+    current_epoch = 1 + LOCK_OPTIONS[0];
+    setup.b_mock.set_block_epoch(current_epoch);
 
     setup.unlock(&first_user, 1, half_balance).assert_ok();
     setup.b_mock.check_esdt_balance(
@@ -137,7 +134,8 @@ fn unlock_early_test() {
     let first_user = setup.first_user.clone();
     let half_balance = USER_BALANCE / 2;
 
-    setup.b_mock.set_block_epoch(1);
+    let mut current_epoch = 1;
+    setup.b_mock.set_block_epoch(current_epoch);
 
     setup
         .lock(
@@ -149,12 +147,15 @@ fn unlock_early_test() {
         .assert_ok();
 
     // unlock early after half a year - with half a year remaining
+    // unlock epoch = 360, so epochs remaining after half year (1 + 365 / 2 = 183)
+    // = 360 - 183 = 177
     let half_year_epochs = EPOCHS_IN_YEAR / 2;
-    setup.b_mock.set_block_epoch(1 + half_year_epochs + 1);
+    current_epoch += half_year_epochs;
+    setup.b_mock.set_block_epoch(current_epoch);
 
-    let penalty_percentage = 499u64; // 1 + 9_999 * 182 / (10 * 365) ~= 1 + 9_999 / 20
+    let penalty_percentage = 485u64; // 1 + 9_999 * 177 / (10 * 365) ~= 1 + 484 = 485
     let expected_penalty_amount = rust_biguint!(half_balance) * penalty_percentage / 10_000u64;
-    let penalty_amount = setup.get_penalty_amount(half_balance, half_year_epochs);
+    let penalty_amount = setup.get_penalty_amount(half_balance, 177);
     assert_eq!(penalty_amount, expected_penalty_amount);
 
     setup.unlock_early(&first_user, 1, half_balance).assert_ok();
@@ -176,7 +177,8 @@ fn reduce_lock_period_test() {
     let first_user = setup.first_user.clone();
     let half_balance = USER_BALANCE / 2;
 
-    setup.b_mock.set_block_epoch(1);
+    let current_epoch = 1;
+    setup.b_mock.set_block_epoch(current_epoch);
 
     setup
         .lock(
@@ -187,10 +189,10 @@ fn reduce_lock_period_test() {
         )
         .assert_ok();
 
-    // reduce half year worth of epochs
-    let half_year_epochs = EPOCHS_IN_YEAR / 2;
+    // reduce half year worth of epochs, 180 ~= 6 months
+    let half_year_epochs = 180;
 
-    let penalty_percentage = 499u64; // 1 + 9_999 * 182 / (10 * 365) ~= 1 + 9_999 / 20
+    let penalty_percentage = 494u64; // 1 + 9_999 * 180 / (10 * 365) ~= 1 + 493 = 494
     let expected_penalty_amount = rust_biguint!(half_balance) * penalty_percentage / 10_000u64;
     let penalty_amount = setup.get_penalty_amount(half_balance, half_year_epochs);
     assert_eq!(penalty_amount, expected_penalty_amount);
@@ -206,7 +208,7 @@ fn reduce_lock_period_test() {
     );
 
     let expected_locked_token_balance = rust_biguint!(half_balance) - &penalty_amount;
-    let expected_new_unlock_epoch = 1 + LOCK_OPTIONS[0] - half_year_epochs;
+    let expected_new_unlock_epoch = to_start_of_month(360 - half_year_epochs);
     setup.b_mock.check_nft_balance(
         &first_user,
         LOCKED_TOKEN_ID,
@@ -232,7 +234,8 @@ fn reduce_lock_period_test() {
     );
 
     // check new energy amount
-    let expected_energy = rust_biguint!(half_year_epochs + 1) * expected_locked_token_balance;
+    let expected_energy =
+        rust_biguint!(expected_new_unlock_epoch - current_epoch) * expected_locked_token_balance;
     let actual_energy = setup.get_user_energy(&first_user);
     assert_eq!(actual_energy, expected_energy);
 }
@@ -243,7 +246,8 @@ fn extend_locking_period_test() {
     let first_user = setup.first_user.clone();
     let half_balance = USER_BALANCE / 2;
 
-    setup.b_mock.set_block_epoch(1);
+    let current_epoch = 1;
+    setup.b_mock.set_block_epoch(current_epoch);
 
     setup
         .lock(
@@ -264,6 +268,7 @@ fn extend_locking_period_test() {
         .extend_locking_period(&first_user, 1, half_balance, LOCK_OPTIONS[1])
         .assert_ok();
 
+    let new_unlock_epoch = to_start_of_month(current_epoch + LOCK_OPTIONS[1]);
     setup.b_mock.check_nft_balance(
         &first_user,
         LOCKED_TOKEN_ID,
@@ -272,11 +277,11 @@ fn extend_locking_period_test() {
         Some(&LockedTokenAttributes::<DebugApi> {
             original_token_id: managed_token_id_wrapped!(BASE_ASSET_TOKEN_ID),
             original_token_nonce: 0,
-            unlock_epoch: 1 + LOCK_OPTIONS[1],
+            unlock_epoch: new_unlock_epoch,
         }),
     );
 
-    let expected_energy = rust_biguint!(LOCK_OPTIONS[1]) * half_balance;
+    let expected_energy = rust_biguint!(new_unlock_epoch - current_epoch) * half_balance;
     let actual_energy = setup.get_user_energy(&first_user);
     assert_eq!(actual_energy, expected_energy);
 


### PR DESCRIPTION
Lock period is now approximated to the closest multiple of 30 epochs, lower than the actual unlock. This makes it so all tokens that unlock (approximately) in the same month, will have the same token nonce.

For example, if a token is locked until epoch 365, and one if locked until epoch 380, both will be approximated to epoch 360.