### PR TITLE
Token merging

### DIFF
--- a/locked-asset/simple-lock-energy/src/lock_options.rs
+++ b/locked-asset/simple-lock-energy/src/lock_options.rs
@@ -77,6 +77,11 @@ pub trait LockOptionsModule {
         unlock_epoch - extra_days
     }
 
+    fn unlock_epoch_to_start_of_month_upper_estimate(&self, unlock_epoch: Epoch) -> Epoch {
+        let lower_bound_unlock = self.unlock_epoch_to_start_of_month(unlock_epoch);
+        lower_bound_unlock + EPOCHS_PER_MONTH
+    }
+
     #[view(getLockOptions)]
     #[storage_mapper("lockOptions")]
     fn lock_options(&self) -> UnorderedSetMapper<Epoch>;

--- a/locked-asset/simple-lock-energy/src/token_merging.rs
+++ b/locked-asset/simple-lock-energy/src/token_merging.rs
@@ -119,6 +119,11 @@ pub trait TokenMergingModule:
                     output_pair.merge_with(amount_attr_pair);
                 }
 
+                let normalized_unlock_epoch = self.unlock_epoch_to_start_of_month_upper_estimate(
+                    output_pair.attributes.unlock_epoch,
+                );
+                output_pair.attributes.unlock_epoch = normalized_unlock_epoch;
+
                 energy.add_after_token_lock(
                     &output_pair.token_amount,
                     output_pair.attributes.unlock_epoch,
@@ -128,16 +133,16 @@ pub trait TokenMergingModule:
                 output_pair
             });
 
-        let normalized_unlock_epoch = self.unlock_epoch_to_start_of_month_upper_estimate(
-            output_amount_attributes.attributes.unlock_epoch,
-        );
         let simulated_lock_payment = EgldOrEsdtTokenPayment::new(
             output_amount_attributes.attributes.original_token_id,
             output_amount_attributes.attributes.original_token_nonce,
             output_amount_attributes.token_amount,
         );
-        let output_tokens =
-            self.lock_and_send(&caller, simulated_lock_payment, normalized_unlock_epoch);
+        let output_tokens = self.lock_and_send(
+            &caller,
+            simulated_lock_payment,
+            output_amount_attributes.attributes.unlock_epoch,
+        );
 
         self.to_esdt_payment(output_tokens)
     }

--- a/locked-asset/simple-lock-energy/src/token_merging.rs
+++ b/locked-asset/simple-lock-energy/src/token_merging.rs
@@ -1,0 +1,147 @@
+elrond_wasm::imports!();
+
+use simple_lock::locked_token::LockedTokenAttributes;
+
+use crate::energy::Energy;
+
+static CANNOT_MERGE_ERR_MSG: &[u8] = b"Cannot merge";
+
+pub trait Mergeable {
+    fn can_merge_with(&self, other: &Self) -> bool;
+
+    fn merge_with(&mut self, other: Self);
+}
+
+impl<M: ManagedTypeApi> Mergeable for EsdtTokenPayment<M> {
+    fn can_merge_with(&self, other: &Self) -> bool {
+        let same_token_id = self.token_identifier == other.token_identifier;
+        let same_token_nonce = self.token_nonce == other.token_nonce;
+
+        same_token_id && same_token_nonce
+    }
+
+    fn merge_with(&mut self, other: Self) {
+        if !self.can_merge_with(&other) {
+            M::error_api_impl().signal_error(CANNOT_MERGE_ERR_MSG);
+        }
+
+        self.amount += other.amount;
+    }
+}
+
+pub struct LockedAmountAttributesPair<M: ManagedTypeApi> {
+    pub token_amount: BigUint<M>,
+    pub attributes: LockedTokenAttributes<M>,
+}
+
+impl<M: ManagedTypeApi> Mergeable for LockedAmountAttributesPair<M> {
+    fn can_merge_with(&self, other: &Self) -> bool {
+        let same_token_id = self.attributes.original_token_id == other.attributes.original_token_id;
+        let same_token_nonce =
+            self.attributes.original_token_nonce == other.attributes.original_token_nonce;
+
+        same_token_id && same_token_nonce
+    }
+
+    fn merge_with(&mut self, other: Self) {
+        if !self.can_merge_with(&other) {
+            M::error_api_impl().signal_error(CANNOT_MERGE_ERR_MSG);
+        }
+
+        let first_unlock_epoch_weighted = &self.token_amount * self.attributes.unlock_epoch;
+        let second_unlock_epoch_weighted = &other.token_amount * other.attributes.unlock_epoch;
+        let total_weight = &self.token_amount + &other.token_amount;
+        let new_unlock_epoch =
+            (first_unlock_epoch_weighted + second_unlock_epoch_weighted) / total_weight;
+
+        self.token_amount += other.token_amount;
+        self.attributes.unlock_epoch = unsafe { new_unlock_epoch.to_u64().unwrap_unchecked() };
+    }
+}
+
+#[elrond_wasm::module]
+pub trait TokenMergingModule:
+    simple_lock::basic_lock_unlock::BasicLockUnlock
+    + simple_lock::locked_token::LockedTokenModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
+    + simple_lock::token_attributes::TokenAttributesModule
+    + crate::util::UtilModule
+    + elrond_wasm_modules::pause::PauseModule
+    + crate::energy::EnergyModule
+    + crate::events::EventsModule
+{
+    #[endpoint(mergeTokens)]
+    fn merge_tokens(&self) -> EsdtTokenPayment {
+        self.require_not_paused();
+
+        let current_epoch = self.blockchain().get_block_epoch();
+        let caller = self.blockchain().get_caller();
+        let locked_token_mapper = self.locked_token();
+
+        let mut payments = self.get_non_empty_payments();
+        locked_token_mapper.require_all_same_token(&payments);
+
+        let first_payment = payments.get(0);
+        payments.remove(0);
+
+        let output_amount_attributes =
+            self.update_energy(&caller, |energy: &mut Energy<Self::Api>| {
+                let first_token_attributes: LockedTokenAttributes<Self::Api> =
+                    locked_token_mapper.get_token_attributes(first_payment.token_nonce);
+                energy.update_after_unlock_any(
+                    &first_payment.amount,
+                    first_token_attributes.unlock_epoch,
+                    current_epoch,
+                );
+
+                locked_token_mapper.nft_burn(first_payment.token_nonce, &first_payment.amount);
+
+                let mut output_pair = LockedAmountAttributesPair {
+                    token_amount: first_payment.amount,
+                    attributes: first_token_attributes,
+                };
+                for payment in &payments {
+                    let attributes: LockedTokenAttributes<Self::Api> =
+                        locked_token_mapper.get_token_attributes(payment.token_nonce);
+                    energy.update_after_unlock_any(
+                        &payment.amount,
+                        attributes.unlock_epoch,
+                        current_epoch,
+                    );
+
+                    locked_token_mapper.nft_burn(payment.token_nonce, &payment.amount);
+
+                    let amount_attr_pair = LockedAmountAttributesPair {
+                        token_amount: payment.amount,
+                        attributes,
+                    };
+                    output_pair.merge_with(amount_attr_pair);
+                }
+
+                energy.add_after_token_lock(
+                    &output_pair.token_amount,
+                    output_pair.attributes.unlock_epoch,
+                    current_epoch,
+                );
+
+                output_pair
+            });
+
+        let new_token_name = output_amount_attributes
+            .attributes
+            .original_token_id
+            .clone()
+            .into_name();
+        let new_token_nonce = self.get_or_create_nonce_for_attributes(
+            &locked_token_mapper,
+            &new_token_name,
+            &output_amount_attributes.attributes,
+        );
+
+        locked_token_mapper.nft_add_quantity_and_send(
+            &caller,
+            new_token_nonce,
+            output_amount_attributes.token_amount,
+        )
+    }
+}

--- a/locked-asset/simple-lock-energy/tests/token_merging_test.rs
+++ b/locked-asset/simple-lock-energy/tests/token_merging_test.rs
@@ -71,4 +71,8 @@ fn token_merging_test() {
             unlock_epoch: expected_merged_token_unlock_epoch,
         }),
     );
+
+    let expected_energy = rust_biguint!(500_000) * expected_merged_token_unlock_epoch;
+    let actual_energy = setup.get_user_energy(&first_user);
+    assert_eq!(expected_energy, actual_energy);
 }

--- a/locked-asset/simple-lock-energy/tests/token_merging_test.rs
+++ b/locked-asset/simple-lock-energy/tests/token_merging_test.rs
@@ -1,0 +1,74 @@
+mod simple_lock_energy_setup;
+
+use elrond_wasm_debug::tx_mock::TxInputESDT;
+use simple_lock::locked_token::LockedTokenAttributes;
+use simple_lock_energy::token_merging::TokenMergingModule;
+use simple_lock_energy_setup::*;
+
+use elrond_wasm_debug::{managed_token_id_wrapped, rust_biguint, DebugApi};
+
+#[test]
+fn token_merging_test() {
+    let _ = DebugApi::dummy();
+    let mut setup = SimpleLockEnergySetup::new(simple_lock_energy::contract_obj);
+    let first_user = setup.first_user.clone();
+
+    let first_token_amount = 400_000;
+    let first_token_unlock_epoch = to_start_of_month(LOCK_OPTIONS[0]);
+    setup
+        .lock(
+            &first_user,
+            BASE_ASSET_TOKEN_ID,
+            first_token_amount,
+            LOCK_OPTIONS[0],
+        )
+        .assert_ok();
+
+    let second_token_amount = 100_000;
+    let second_token_unlock_epoch = to_start_of_month(LOCK_OPTIONS[1]);
+    setup
+        .lock(
+            &first_user,
+            BASE_ASSET_TOKEN_ID,
+            second_token_amount,
+            LOCK_OPTIONS[1],
+        )
+        .assert_ok();
+
+    let payments = [
+        TxInputESDT {
+            token_identifier: LOCKED_TOKEN_ID.to_vec(),
+            nonce: 1,
+            value: rust_biguint!(400_000),
+        },
+        TxInputESDT {
+            token_identifier: LOCKED_TOKEN_ID.to_vec(),
+            nonce: 2,
+            value: rust_biguint!(100_000),
+        },
+    ];
+    setup
+        .b_mock
+        .execute_esdt_multi_transfer(&first_user, &setup.sc_wrapper, &payments[..], |sc| {
+            let _ = sc.merge_tokens();
+        })
+        .assert_ok();
+
+    assert_eq!(first_token_unlock_epoch, 360);
+    assert_eq!(second_token_unlock_epoch, 1800);
+
+    // (400_000 * 360 + 100_000 * 1800) / 500_000 = 648
+    // -> start of month (upper) = 660
+    let expected_merged_token_unlock_epoch = 660;
+    setup.b_mock.check_nft_balance(
+        &first_user,
+        LOCKED_TOKEN_ID,
+        3,
+        &rust_biguint!(first_token_amount + second_token_amount),
+        Some(&LockedTokenAttributes::<DebugApi> {
+            original_token_id: managed_token_id_wrapped!(BASE_ASSET_TOKEN_ID),
+            original_token_nonce: 0,
+            unlock_epoch: expected_merged_token_unlock_epoch,
+        }),
+    );
+}

--- a/locked-asset/simple-lock-energy/wasm/src/lib.rs
+++ b/locked-asset/simple-lock-energy/wasm/src/lib.rs
@@ -22,6 +22,7 @@ elrond_wasm_node::wasm_endpoints! {
         isPaused
         issueLockedToken
         lockTokens
+        mergeTokens
         pause
         reduceLockPeriod
         removeLockOptions


### PR DESCRIPTION
Allow merging of multiple tokens under a single one. This is done through a weighted average based on token amount, and original unlock epoch.

The final unlock epoch is estimated towards the upper bound instead of the usual floor -> start of month. This is done to prevent exploits where merging would be used to keep reducing the lock period indefinitely.