### PR TITLE
Farm: Add optional argument of original_caller

### DIFF
--- a/common/modules/farm/config/src/config.rs
+++ b/common/modules/farm/config/src/config.rs
@@ -38,4 +38,9 @@ pub trait ConfigModule: pausable::PausableModule + permissions_module::Permissio
     #[view(getDivisionSafetyConstant)]
     #[storage_mapper("division_safety_constant")]
     fn division_safety_constant(&self) -> SingleValueMapper<BigUint>;
+
+    #[view(getKnownProxyAddresses)]
+    #[storage_mapper("known_proxy_addresses")]
+    fn known_proxy_addresses(&self) -> UnorderedSetMapper<ManagedAddress>;
+
 }

--- a/common/modules/farm/config/src/config.rs
+++ b/common/modules/farm/config/src/config.rs
@@ -38,9 +38,4 @@ pub trait ConfigModule: pausable::PausableModule + permissions_module::Permissio
     #[view(getDivisionSafetyConstant)]
     #[storage_mapper("division_safety_constant")]
     fn division_safety_constant(&self) -> SingleValueMapper<BigUint>;
-
-    #[view(getKnownProxyAddresses)]
-    #[storage_mapper("known_proxy_addresses")]
-    fn known_proxy_addresses(&self) -> UnorderedSetMapper<ManagedAddress>;
-
 }

--- a/dex/farm/Cargo.toml
+++ b/dex/farm/Cargo.toml
@@ -41,6 +41,9 @@ path = "../../common/modules/pausable"
 [dependencies.permissions_module]
 path = "../../common/modules/permissions_module"
 
+[dependencies.sc_whitelist_module]
+path = "../../common/modules/sc_whitelist_module"
+
 [dependencies.pair]
 path = "../pair"
 

--- a/dex/farm/src/base_functions.rs
+++ b/dex/farm/src/base_functions.rs
@@ -223,26 +223,4 @@ pub trait BaseFunctionsModule:
         );
     }
 
-    // fn require_known_proxy_from_optional(&self, opt_orig_caller: OptionalValue<ManagedAddress>) -> ManagedAddress {
-    //     let caller = self.blockchain().get_caller();
-    //     match opt_orig_caller {
-    //         OptionalValue::Some(orig_caller) => {
-    //             self.require_sc_address_whitelisted(&caller);
-    //             orig_caller
-    //         },
-    //         OptionalValue::None => caller,
-    //     }
-    // }
-
-    // #[endpoint(addKnownProxy)]
-    // fn add_known_proxy(&self, known_proxy: ManagedAddress) {
-    //     self.require_caller_has_owner_or_admin_permissions();
-    //     self.known_proxy_addresses().insert(known_proxy);
-    // }
-
-    // #[endpoint(removeKnownProxy)]
-    // fn remove_known_proxy(&self, known_proxy: ManagedAddress) {
-    //     self.require_caller_has_owner_or_admin_permissions();
-    //     self.known_proxy_addresses().swap_remove(&known_proxy);
-    // }
 }

--- a/dex/farm/src/base_functions.rs
+++ b/dex/farm/src/base_functions.rs
@@ -222,4 +222,29 @@ pub trait BaseFunctionsModule:
             "May only call this function through VM query"
         );
     }
+
+    fn require_known_proxy_from_optional(&self, opt_orig_caller: OptionalValue<ManagedAddress>) -> ManagedAddress {
+        match opt_orig_caller {
+            OptionalValue::Some(dest) => {
+                require!(
+                    self.known_proxy_addresses().contains(&dest),
+                    "Only known proxies allowed"
+                );
+                dest
+            },
+            OptionalValue::None => self.blockchain().get_caller(),
+        }
+    }
+
+    #[endpoint(addKnownProxy)]
+    fn add_known_proxy(&self, known_proxy: ManagedAddress) {
+        self.require_caller_has_owner_or_admin_permissions();
+        self.known_proxy_addresses().insert(known_proxy);
+    }
+
+    #[endpoint(removeKnownProxy)]
+    fn remove_known_proxy(&self, known_proxy: ManagedAddress) {
+        self.require_caller_has_owner_or_admin_permissions();
+        self.known_proxy_addresses().swap_remove(&known_proxy);
+    }
 }

--- a/dex/farm/src/base_functions.rs
+++ b/dex/farm/src/base_functions.rs
@@ -223,28 +223,26 @@ pub trait BaseFunctionsModule:
         );
     }
 
-    fn require_known_proxy_from_optional(&self, opt_orig_caller: OptionalValue<ManagedAddress>) -> ManagedAddress {
-        match opt_orig_caller {
-            OptionalValue::Some(dest) => {
-                require!(
-                    self.known_proxy_addresses().contains(&dest),
-                    "Only known proxies allowed"
-                );
-                dest
-            },
-            OptionalValue::None => self.blockchain().get_caller(),
-        }
-    }
+    // fn require_known_proxy_from_optional(&self, opt_orig_caller: OptionalValue<ManagedAddress>) -> ManagedAddress {
+    //     let caller = self.blockchain().get_caller();
+    //     match opt_orig_caller {
+    //         OptionalValue::Some(orig_caller) => {
+    //             self.require_sc_address_whitelisted(&caller);
+    //             orig_caller
+    //         },
+    //         OptionalValue::None => caller,
+    //     }
+    // }
 
-    #[endpoint(addKnownProxy)]
-    fn add_known_proxy(&self, known_proxy: ManagedAddress) {
-        self.require_caller_has_owner_or_admin_permissions();
-        self.known_proxy_addresses().insert(known_proxy);
-    }
+    // #[endpoint(addKnownProxy)]
+    // fn add_known_proxy(&self, known_proxy: ManagedAddress) {
+    //     self.require_caller_has_owner_or_admin_permissions();
+    //     self.known_proxy_addresses().insert(known_proxy);
+    // }
 
-    #[endpoint(removeKnownProxy)]
-    fn remove_known_proxy(&self, known_proxy: ManagedAddress) {
-        self.require_caller_has_owner_or_admin_permissions();
-        self.known_proxy_addresses().swap_remove(&known_proxy);
-    }
+    // #[endpoint(removeKnownProxy)]
+    // fn remove_known_proxy(&self, known_proxy: ManagedAddress) {
+    //     self.require_caller_has_owner_or_admin_permissions();
+    //     self.known_proxy_addresses().swap_remove(&known_proxy);
+    // }
 }

--- a/dex/farm/src/lib.rs
+++ b/dex/farm/src/lib.rs
@@ -32,6 +32,7 @@ pub trait Farm:
     + farm_token_merge::FarmTokenMergeModule
     + pausable::PausableModule
     + permissions_module::PermissionsModule
+    + sc_whitelist_module::SCWhitelistModule
     + events::EventsModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
     + base_functions::BaseFunctionsModule
@@ -91,37 +92,60 @@ pub trait Farm:
     #[payable("*")]
     #[endpoint(claimRewards)]
     fn claim_rewards_endpoint(&self, opt_orig_caller: OptionalValue<ManagedAddress>) -> ClaimRewardsResultType<Self::Api> {
-        let orig_caller = self.require_known_proxy_from_optional(opt_orig_caller);
+        let caller = self.blockchain().get_caller();
+        let orig_caller = match opt_orig_caller {
+            OptionalValue::Some(opt_caller) => {
+                self.require_sc_address_whitelisted(&caller);
+                opt_caller
+            },
+            OptionalValue::None => caller.clone(),
+        };
+
         let claim_rewards_result = self.claim_rewards(&orig_caller);
         let (output_farm_token_payment, rewards_payment) =
             claim_rewards_result.clone().into_tuple();
 
-        let caller = self.blockchain().get_caller();
-        self.send_payment_non_zero(&caller, &output_farm_token_payment);
-        self.send_payment_non_zero(&caller, &rewards_payment);
+        self.send_payment_non_zero(&orig_caller, &output_farm_token_payment);
+        self.send_payment_non_zero(&orig_caller, &rewards_payment);
         claim_rewards_result
     }
 
     #[payable("*")]
     #[endpoint(compoundRewards)]
     fn compound_rewards_endpoint(&self, opt_orig_caller: OptionalValue<ManagedAddress>) -> CompoundRewardsResultType<Self::Api> {
-        let orig_caller = self.require_known_proxy_from_optional(opt_orig_caller);
+        let caller = self.blockchain().get_caller();
+        let orig_caller = match opt_orig_caller {
+            OptionalValue::Some(opt_caller) => {
+                self.require_sc_address_whitelisted(&caller);
+                opt_caller
+            },
+            OptionalValue::None => caller.clone(),
+        };
+
         let output_farm_token_payment = self.compound_rewards(&orig_caller);
 
-        let caller = self.blockchain().get_caller();
-        self.send_payment_non_zero(&caller, &output_farm_token_payment);
+        // let caller = self.blockchain().get_caller();
+        self.send_payment_non_zero(&orig_caller, &output_farm_token_payment);
         output_farm_token_payment
     }
 
     #[payable("*")]
     #[endpoint(exitFarm)]
     fn exit_farm_endpoint(&self, opt_orig_caller: OptionalValue<ManagedAddress>) -> ExitFarmResultType<Self::Api> {
-        let orig_caller = self.require_known_proxy_from_optional(opt_orig_caller);
+        let caller = self.blockchain().get_caller();
+        let orig_caller = match opt_orig_caller {
+            OptionalValue::Some(opt_caller) => {
+                self.require_sc_address_whitelisted(&caller);
+                opt_caller
+            },
+            OptionalValue::None => caller.clone(),
+        };
         let exit_farm_result = self.exit_farm(&orig_caller);
         let (farming_token_payment, reward_payment) = exit_farm_result.clone().into_tuple();
-        let caller = self.blockchain().get_caller();
-        self.send_payment_non_zero(&caller, &farming_token_payment);
-        self.send_payment_non_zero(&caller, &reward_payment);
+
+        // let caller = self.blockchain().get_caller();
+        self.send_payment_non_zero(&orig_caller, &farming_token_payment);
+        self.send_payment_non_zero(&orig_caller, &reward_payment);
         exit_farm_result
     }
 
@@ -147,8 +171,8 @@ pub trait Farm:
 
     #[payable("*")]
     #[endpoint(mergeFarmTokens)]
-    fn merge_farm_tokens_endpoint(&self, opt_orig_caller: OptionalValue<ManagedAddress>) -> EsdtTokenPayment<Self::Api> {
-        let caller = self.require_known_proxy_from_optional(opt_orig_caller);
+    fn merge_farm_tokens_endpoint(&self) -> EsdtTokenPayment<Self::Api> {
+        let caller = self.blockchain().get_caller();
         let new_tokens = self.merge_farm_tokens();
         self.send_payment_non_zero(&caller, &new_tokens);
         new_tokens
@@ -171,4 +195,17 @@ pub trait Farm:
         self.require_caller_has_admin_permissions();
         self.set_per_block_rewards(per_block_amount);
     }
+
+    #[endpoint(addKnownProxy)]
+    fn add_known_proxy(&self, known_proxy: ManagedAddress) {
+        self.require_caller_has_owner_or_admin_permissions();
+        self.add_sc_address_to_whitelist(known_proxy);
+    }
+
+    #[endpoint(removeKnownProxy)]
+    fn remove_known_proxy(&self, known_proxy: ManagedAddress) {
+        self.require_caller_has_owner_or_admin_permissions();
+        self.remove_sc_address_from_whitelist(known_proxy);
+    }
+
 }

--- a/dex/farm/tests/farm_test.rs
+++ b/dex/farm/tests/farm_test.rs
@@ -17,6 +17,7 @@ use farm::Farm;
 use farm_boosted_yields::FarmBoostedYieldsModule;
 use farm_token::FarmTokenModule;
 use pausable::{PausableModule, State};
+use sc_whitelist_module::SCWhitelistModule;
 
 static REWARD_TOKEN_ID: &[u8] = b"REW-123456";
 static FARMING_TOKEN_ID: &[u8] = b"LPTOK-123456";
@@ -292,7 +293,7 @@ fn farm_known_proxy_test() {
     farm_setup
         .b_mock
         .check_nft_balance::<FarmTokenAttributes<DebugApi>>(
-            &second_user,
+            &first_user,
             FARM_TOKEN_ID,
             4,
             &rust_biguint!(second_farm_token_amount),
@@ -300,9 +301,9 @@ fn farm_known_proxy_test() {
         );
 
     farm_setup.b_mock.check_esdt_balance(
-        &second_user,
+        &first_user,
         REWARD_TOKEN_ID,
-        &rust_biguint!(second_received_reward_amt),
+        &rust_biguint!(second_received_reward_amt + first_received_reward_amt),
     );
 }
 
@@ -452,7 +453,7 @@ where
     pub fn add_known_proxy(&mut self, known_proxy: &Address) {
         self.b_mock
             .execute_tx(&self.owner, &self.farm_wrapper, &rust_biguint!(0), |sc| {
-                sc.add_known_proxy(managed_address!(known_proxy));
+                sc.add_sc_address_to_whitelist(managed_address!(known_proxy));
             })
             .assert_ok();
     }

--- a/dex/farm/tests/farm_test.rs
+++ b/dex/farm/tests/farm_test.rs
@@ -221,7 +221,7 @@ fn farm_known_proxy_test() {
     // second user enter farm
     let second_farm_token_amount = 50_000_000;
     let second_user = farm_setup.second_user.clone();
-    farm_setup.enter_farm(&second_user, second_farm_token_amount);
+    farm_setup.enter_farm(&first_user, second_farm_token_amount);
 
     farm_setup.add_known_proxy(&first_user);
 
@@ -282,10 +282,10 @@ fn farm_known_proxy_test() {
     farm_setup.b_mock.dump_state();
     // first user claims for second user
     let second_received_reward_amt = farm_setup.claim_rewards_known_proxy(
-        &first_user,
+        &second_user,
         2,
         second_farm_token_amount,
-        &second_user,
+        &first_user,
     );
     assert_eq!(second_received_reward_amt, second_expected_rewards_amt);
 
@@ -452,8 +452,7 @@ where
     pub fn add_known_proxy(&mut self, known_proxy: &Address) {
         self.b_mock
             .execute_tx(&self.owner, &self.farm_wrapper, &rust_biguint!(0), |sc| {
-                sc.known_proxy_addresses()
-                    .insert(managed_address!(known_proxy));
+                sc.add_known_proxy(managed_address!(known_proxy));
             })
             .assert_ok();
     }

--- a/dex/farm/tests/farm_test.rs
+++ b/dex/farm/tests/farm_test.rs
@@ -1,5 +1,6 @@
 use common_structs::FarmTokenAttributes;
 use config::ConfigModule;
+use elrond_wasm::elrond_codec::multi_types::OptionalValue;
 use elrond_wasm::{
     storage::mappers::StorageTokenWrapper,
     types::{Address, BigInt, EsdtLocalRole, MultiValueEncoded},
@@ -9,6 +10,7 @@ use elrond_wasm_debug::{
     testing_framework::{BlockchainStateWrapper, ContractObjWrapper},
     DebugApi,
 };
+
 use energy_factory_mock::EnergyFactoryMock;
 use energy_query::{Energy, EnergyQueryModule};
 use farm::Farm;
@@ -21,7 +23,7 @@ static FARMING_TOKEN_ID: &[u8] = b"LPTOK-123456";
 static FARM_TOKEN_ID: &[u8] = b"FARM-123456";
 const DIV_SAFETY: u64 = 1_000_000_000_000;
 const PER_BLOCK_REWARD_AMOUNT: u64 = 1_000;
-const FARMING_TOKEN_BALANCE: u64 = 100_000_000;
+const FARMING_TOKEN_BALANCE: u64 = 200_000_000;
 const BOOSTED_YIELDS_PERCENTAGE: u64 = 2_500; // 25%
 
 #[test]
@@ -206,6 +208,104 @@ fn farm_with_boosted_yields_test() {
     );
 }
 
+#[test]
+fn farm_known_proxy_test() {
+    let _ = DebugApi::dummy();
+    let mut farm_setup = FarmSetup::new(farm::contract_obj, energy_factory_mock::contract_obj);
+
+    // first user enter farm
+    let first_farm_token_amount = 100_000_000;
+    let first_user = farm_setup.first_user.clone();
+    farm_setup.enter_farm(&first_user, first_farm_token_amount);
+
+    // second user enter farm
+    let second_farm_token_amount = 50_000_000;
+    let second_user = farm_setup.second_user.clone();
+    farm_setup.enter_farm(&second_user, second_farm_token_amount);
+
+    farm_setup.add_known_proxy(&first_user);
+
+    // advance blocks - 10 blocks - 10 * 1_000 = 10_000 total rewards
+    farm_setup.b_mock.set_block_nonce(10);
+
+    let total_farm_tokens = first_farm_token_amount + second_farm_token_amount;
+
+    // calculate rewards - first user
+    let first_attributes = FarmTokenAttributes {
+        reward_per_share: managed_biguint!(0),
+        original_entering_epoch: 0,
+        entering_epoch: 0,
+        initial_farming_amount: managed_biguint!(first_farm_token_amount),
+        compounded_reward: managed_biguint!(0),
+        current_farm_amount: managed_biguint!(first_farm_token_amount),
+    };
+    let first_rewards_amt =
+        farm_setup.calculate_rewards(&first_user, first_farm_token_amount, first_attributes);
+    let first_expected_rewards_amt = first_farm_token_amount * 10_000 / total_farm_tokens;
+    assert_eq!(first_rewards_amt, first_expected_rewards_amt);
+
+    // calculate rewards - second user
+    let second_attributes = FarmTokenAttributes {
+        reward_per_share: managed_biguint!(0),
+        original_entering_epoch: 0,
+        entering_epoch: 0,
+        initial_farming_amount: managed_biguint!(second_farm_token_amount),
+        compounded_reward: managed_biguint!(0),
+        current_farm_amount: managed_biguint!(second_farm_token_amount),
+    };
+    let second_rewards_amt =
+        farm_setup.calculate_rewards(&second_user, second_farm_token_amount, second_attributes);
+    let second_expected_rewards_amt = second_farm_token_amount * 10_000 / total_farm_tokens;
+    assert_eq!(second_rewards_amt, second_expected_rewards_amt);
+
+    // first user claim
+    let first_received_reward_amt =
+        farm_setup.claim_rewards(&first_user, 1, first_farm_token_amount);
+    assert_eq!(first_received_reward_amt, first_expected_rewards_amt);
+
+    farm_setup
+        .b_mock
+        .check_nft_balance::<FarmTokenAttributes<DebugApi>>(
+            &first_user,
+            FARM_TOKEN_ID,
+            3,
+            &rust_biguint!(first_farm_token_amount),
+            None,
+        );
+
+    farm_setup.b_mock.check_esdt_balance(
+        &first_user,
+        REWARD_TOKEN_ID,
+        &rust_biguint!(first_received_reward_amt),
+    );
+
+    farm_setup.b_mock.dump_state();
+    // first user claims for second user
+    let second_received_reward_amt = farm_setup.claim_rewards_known_proxy(
+        &first_user,
+        2,
+        second_farm_token_amount,
+        &second_user,
+    );
+    assert_eq!(second_received_reward_amt, second_expected_rewards_amt);
+
+    farm_setup
+        .b_mock
+        .check_nft_balance::<FarmTokenAttributes<DebugApi>>(
+            &second_user,
+            FARM_TOKEN_ID,
+            4,
+            &rust_biguint!(second_farm_token_amount),
+            None,
+        );
+
+    farm_setup.b_mock.check_esdt_balance(
+        &second_user,
+        REWARD_TOKEN_ID,
+        &rust_biguint!(second_received_reward_amt),
+    );
+}
+
 pub struct FarmSetup<FarmObjBuilder, EnergyFactoryBuilder>
 where
     FarmObjBuilder: 'static + Copy + Fn() -> farm::ContractObj<DebugApi>,
@@ -349,6 +449,15 @@ where
             .assert_ok();
     }
 
+    pub fn add_known_proxy(&mut self, known_proxy: &Address) {
+        self.b_mock
+            .execute_tx(&self.owner, &self.farm_wrapper, &rust_biguint!(0), |sc| {
+                sc.known_proxy_addresses()
+                    .insert(managed_address!(known_proxy));
+            })
+            .assert_ok();
+    }
+
     pub fn enter_farm(&mut self, user: &Address, farming_token_amount: u64) {
         self.last_farm_token_nonce += 1;
 
@@ -415,7 +524,51 @@ where
                 farm_token_nonce,
                 &rust_biguint!(farm_token_amount),
                 |sc| {
-                    let (out_farm_token, out_reward_token) = sc.claim_rewards_endpoint().into_tuple();
+                    let (out_farm_token, out_reward_token) =
+                        sc.claim_rewards_endpoint(OptionalValue::None).into_tuple();
+                    assert_eq!(
+                        out_farm_token.token_identifier,
+                        managed_token_id!(FARM_TOKEN_ID)
+                    );
+                    assert_eq!(out_farm_token.token_nonce, expected_farm_token_nonce);
+                    assert_eq!(out_farm_token.amount, managed_biguint!(farm_token_amount));
+
+                    assert_eq!(
+                        out_reward_token.token_identifier,
+                        managed_token_id!(REWARD_TOKEN_ID)
+                    );
+                    assert_eq!(out_reward_token.token_nonce, 0);
+
+                    result = out_reward_token.amount.to_u64().unwrap();
+                },
+            )
+            .assert_ok();
+
+        result
+    }
+
+    pub fn claim_rewards_known_proxy(
+        &mut self,
+        user: &Address,
+        farm_token_nonce: u64,
+        farm_token_amount: u64,
+        known_proxy: &Address,
+    ) -> u64 {
+        self.last_farm_token_nonce += 1;
+
+        let expected_farm_token_nonce = self.last_farm_token_nonce;
+        let mut result = 0;
+        self.b_mock
+            .execute_esdt_transfer(
+                known_proxy,
+                &self.farm_wrapper,
+                FARM_TOKEN_ID,
+                farm_token_nonce,
+                &rust_biguint!(farm_token_amount),
+                |sc| {
+                    let (out_farm_token, out_reward_token) = sc
+                        .claim_rewards_endpoint(OptionalValue::Some(managed_address!(user)))
+                        .into_tuple();
                     assert_eq!(
                         out_farm_token.token_identifier,
                         managed_token_id!(FARM_TOKEN_ID)
@@ -446,7 +599,28 @@ where
                 farm_token_nonce,
                 &rust_biguint!(farm_token_amount),
                 |sc| {
-                    let _ = sc.exit_farm_endpoint();
+                    let _ = sc.exit_farm_endpoint(OptionalValue::None);
+                },
+            )
+            .assert_ok();
+    }
+
+    pub fn exit_farm_known_proxy(
+        &mut self,
+        user: &Address,
+        farm_token_nonce: u64,
+        farm_token_amount: u64,
+        known_proxy: &Address,
+    ) {
+        self.b_mock
+            .execute_esdt_transfer(
+                known_proxy,
+                &self.farm_wrapper,
+                FARM_TOKEN_ID,
+                farm_token_nonce,
+                &rust_biguint!(farm_token_amount),
+                |sc| {
+                    let _ = sc.exit_farm_endpoint(OptionalValue::Some(managed_address!(user)));
                 },
             )
             .assert_ok();

--- a/dex/fuzz/src/fuzz_farm.rs
+++ b/dex/fuzz/src/fuzz_farm.rs
@@ -176,7 +176,7 @@ pub mod fuzz_farm_test {
             farm_token_nonce,
             &farm_out_amount,
             |sc| {
-                sc.exit_farm_endpoint();
+                sc.exit_farm_endpoint(OptionalValue::None);
             },
         );
 
@@ -266,7 +266,7 @@ pub mod fuzz_farm_test {
             &farm_setup.farm_wrapper,
             &payments,
             |sc| {
-                sc.claim_rewards_endpoint();
+                sc.claim_rewards_endpoint(OptionalValue::None);
             },
         );
 
@@ -375,7 +375,7 @@ pub mod fuzz_farm_test {
             &farm_setup.farm_wrapper,
             &payments,
             |sc| {
-                sc.compound_rewards_endpoint();
+                sc.compound_rewards_endpoint(OptionalValue::None);
             },
         );
 

--- a/dex/pair/src/lib.rs
+++ b/dex/pair/src/lib.rs
@@ -99,7 +99,10 @@ pub trait Pair<ContractReader>:
             self.add_permissions(router_owner_address, all_permissions);
         } else {
             self.add_permissions(router_address, Permissions::OWNER | Permissions::PAUSE);
-            self.add_permissions(router_owner_address, Permissions::OWNER | Permissions::PAUSE);
+            self.add_permissions(
+                router_owner_address,
+                Permissions::OWNER | Permissions::PAUSE,
+            );
             self.add_permissions_for_all(admins, Permissions::ADMIN);
         };
     }

--- a/dex/tests/farm_review_distribution.rs
+++ b/dex/tests/farm_review_distribution.rs
@@ -1,5 +1,6 @@
 use std::ops::Mul;
 
+use elrond_wasm::elrond_codec::multi_types::OptionalValue;
 use elrond_wasm::storage::mappers::StorageTokenWrapper;
 use elrond_wasm::types::{Address, BigUint, EsdtLocalRole, ManagedAddress, MultiValueEncoded};
 use elrond_wasm_debug::{
@@ -208,7 +209,7 @@ fn exit_farm<FarmObjBuilder>(
             farm_token_nonce,
             &farm_out_amount.clone(),
             |sc| {
-                let multi_result = sc.exit_farm_endpoint();
+                let multi_result = sc.exit_farm_endpoint(OptionalValue::None);
 
                 let (first_result, second_result) = multi_result.into_tuple();
 

--- a/dex/tests/farm_rs_test.rs
+++ b/dex/tests/farm_rs_test.rs
@@ -1,4 +1,5 @@
 use common_structs::FarmTokenAttributes;
+use elrond_wasm::elrond_codec::multi_types::OptionalValue;
 use elrond_wasm::storage::mappers::StorageTokenWrapper;
 use elrond_wasm::types::{
     Address, EsdtLocalRole, EsdtTokenPayment, ManagedAddress, MultiValueEncoded,
@@ -224,7 +225,7 @@ fn exit_farm<FarmObjBuilder>(
             farm_token_nonce,
             &rust_biguint!(farm_token_amount),
             |sc| {
-                let multi_result = sc.exit_farm_endpoint();
+                let multi_result = sc.exit_farm_endpoint(OptionalValue::None);
 
                 let (first_result, second_result) = multi_result.into_tuple();
 
@@ -278,7 +279,7 @@ fn claim_rewards<FarmObjBuilder>(
             farm_token_nonce,
             &rust_biguint!(farm_token_amount),
             |sc| {
-                let multi_result = sc.claim_rewards_endpoint();
+                let multi_result = sc.claim_rewards_endpoint(OptionalValue::None);
 
                 let (first_result, second_result) = multi_result.into_tuple();
 

--- a/dex/tests/pair_rs_test.rs
+++ b/dex/tests/pair_rs_test.rs
@@ -1331,9 +1331,7 @@ fn fees_collector_pair_test() {
             &rust_biguint!(0),
             |sc| {
                 sc.init();
-                let _ = sc
-                    .known_contracts()
-                    .insert(managed_address!(&pair_addr));
+                let _ = sc.known_contracts().insert(managed_address!(&pair_addr));
 
                 let mut tokens = MultiValueEncoded::new();
                 tokens.push(managed_token_id!(WEGLD_TOKEN_ID));

--- a/energy-integration/common-modules/weekly-rewards-splitting/src/lib.rs
+++ b/energy-integration/common-modules/weekly-rewards-splitting/src/lib.rs
@@ -3,8 +3,8 @@
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
-pub mod ongoing_operation;
 pub mod events;
+pub mod ongoing_operation;
 
 use common_types::{PaymentsVec, TokenAmountPair, TokenAmountPairsVec};
 use energy_query::Energy;

--- a/energy-integration/common-types/src/lib.rs
+++ b/energy-integration/common-types/src/lib.rs
@@ -11,7 +11,15 @@ pub type TokenAmountPairsVec<M> = ManagedVec<M, TokenAmountPair<M>>;
 pub type PaymentsVec<M> = ManagedVec<M, EsdtTokenPayment<M>>;
 
 #[derive(
-    TypeAbi, TopEncode, TopDecode, NestedEncode, NestedDecode, ManagedVecItem, PartialEq, Debug, Clone,
+    TypeAbi,
+    TopEncode,
+    TopDecode,
+    NestedEncode,
+    NestedDecode,
+    ManagedVecItem,
+    PartialEq,
+    Debug,
+    Clone,
 )]
 pub struct TokenAmountPair<M: ManagedTypeApi> {
     pub token: TokenIdentifier<M>,

--- a/farm-staking/farm-staking-proxy/src/external_contracts_interactions.rs
+++ b/farm-staking/farm-staking-proxy/src/external_contracts_interactions.rs
@@ -23,10 +23,11 @@ pub trait ExternalContractsInteractionsModule:
         lp_farm_token_nonce: u64,
         lp_farm_token_amount: BigUint,
     ) -> LpFarmClaimRewardsResult<Self::Api> {
+        let orig_caller = self.blockchain().get_caller();
         let lp_farm_address = self.lp_farm_address().get();
         let lp_farm_result: ClaimRewardsResultType<Self::Api> = self
             .lp_farm_proxy_obj(lp_farm_address)
-            .claim_rewards_endpoint()
+            .claim_rewards_endpoint(orig_caller)
             .add_esdt_token_transfer(
                 lp_farm_token_id.clone(),
                 lp_farm_token_nonce,
@@ -53,11 +54,12 @@ pub trait ExternalContractsInteractionsModule:
         lp_farm_token_nonce: u64,
         lp_farm_token_amount: BigUint,
     ) -> LpFarmExitResult<Self::Api> {
+        let orig_caller = self.blockchain().get_caller();
         let lp_farm_token_id = self.lp_farm_token_id().get();
         let lp_farm_address = self.lp_farm_address().get();
         let exit_farm_result: ExitFarmResultType<Self::Api> = self
             .lp_farm_proxy_obj(lp_farm_address)
-            .exit_farm_endpoint()
+            .exit_farm_endpoint(orig_caller)
             .add_esdt_token_transfer(lp_farm_token_id, lp_farm_token_nonce, lp_farm_token_amount)
             .execute_on_dest_context();
         let (mut lp_tokens, mut lp_farm_rewards) = exit_farm_result.into_tuple();

--- a/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_interactions/mod.rs
+++ b/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_interactions/mod.rs
@@ -1,6 +1,6 @@
 use elrond_wasm::types::Address;
 use elrond_wasm_debug::{
-    managed_biguint, rust_biguint,
+    managed_address, managed_biguint, rust_biguint,
     testing_framework::{BlockchainStateWrapper, ContractObjWrapper},
     tx_mock::TxInputESDT,
     DebugApi,
@@ -10,6 +10,7 @@ use farm_staking::UnbondSftAttributes;
 use farm_staking::*;
 use farm_staking_proxy::dual_yield_token::DualYieldTokenAttributes;
 use farm_staking_proxy::*;
+use sc_whitelist_module::SCWhitelistModule;
 
 use crate::{
     constants::*,
@@ -95,6 +96,12 @@ where
             &mut b_mock,
             &staking_farm_wrapper,
         );
+
+        b_mock
+            .execute_tx(&owner_addr, &lp_farm_wrapper, &rust_zero, |sc| {
+                sc.add_sc_address_to_whitelist(managed_address!(proxy_wrapper.address_ref()));
+            })
+            .assert_ok();
 
         FarmStakingSetup {
             owner_addr,

--- a/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_setup/mod.rs
+++ b/farm-staking/farm-staking-proxy/tests/staking_farm_with_lp_staking_contract_setup/mod.rs
@@ -13,9 +13,9 @@ use farm_staking_config::ConfigModule as _;
 use farm_staking::custom_rewards::CustomRewardsModule;
 use farm_staking_proxy::dual_yield_token::DualYieldTokenModule;
 use farm_staking_proxy::*;
-use sc_whitelist_module::SCWhitelistModule;
 use farm_token::FarmTokenModule;
 use pausable::{PausableModule, State};
+use sc_whitelist_module::SCWhitelistModule;
 
 use crate::constants::*;
 

--- a/locked-asset/proxy_dex/src/proxy_farm.rs
+++ b/locked-asset/proxy_dex/src/proxy_farm.rs
@@ -438,8 +438,9 @@ pub trait ProxyFarmModule:
         farm_token_nonce: Nonce,
         amount: &BigUint,
     ) -> ExitFarmResultType<Self::Api> {
+        let orig_caller = self.blockchain().get_caller();
         self.farm_contract_proxy(farm_address.clone())
-            .exit_farm_endpoint()
+            .exit_farm_endpoint(orig_caller)
             .add_esdt_token_transfer(farm_token_id.clone(), farm_token_nonce, amount.clone())
             .execute_on_dest_context()
     }
@@ -458,8 +459,9 @@ pub trait ProxyFarmModule:
             amount.clone(),
         ));
 
+        let orig_caller = self.blockchain().get_caller();
         self.farm_contract_proxy(farm_address.clone())
-            .claim_rewards_endpoint()
+            .claim_rewards_endpoint(orig_caller)
             .with_multi_token_transfer(payments)
             .execute_on_dest_context()
     }
@@ -478,8 +480,9 @@ pub trait ProxyFarmModule:
             amount.clone(),
         ));
 
+        let orig_caller = self.blockchain().get_caller();
         self.farm_contract_proxy(farm_address.clone())
-            .compound_rewards_endpoint()
+            .compound_rewards_endpoint(orig_caller)
             .with_multi_token_transfer(payments)
             .execute_on_dest_context()
     }

--- a/locked-asset/tests/distribution_mandos_go_test.rs
+++ b/locked-asset/tests/distribution_mandos_go_test.rs
@@ -29,7 +29,6 @@
 //     elrond_wasm_debug::mandos_go("mandos/claim_rewards_proxy_after_mint_rewards.scen.json");
 // }
 // */
-
 // #[test]
 // fn clear_unclaimable_assets_go() {
 //     elrond_wasm_debug::mandos_go("mandos/clear_unclaimable_assets.scen.json");
@@ -73,7 +72,6 @@
 //     elrond_wasm_debug::mandos_go("mandos/exit_farm_proxy_after_mint_rewards.scen.json");
 // }
 // */
-
 // #[test]
 // fn exit_mex_farm_proxy_after_mint_rewards_go() {
 //     elrond_wasm_debug::mandos_go("mandos/exit_mex_farm_proxy_after_mint_rewards.scen.json");
@@ -138,4 +136,3 @@
 // fn unlock_assets_basic_go() {
 //     elrond_wasm_debug::mandos_go("mandos/unlock_assets_basic.scen.json");
 // }
-


### PR DESCRIPTION
Add optional argument of original_caller in farm endpoints If original_caller exists - verify that caller is the proxy contract