### PR TITLE
guard for empty rewards on fees collector claim

### DIFF
--- a/energy-integration/fees-collector/src/lib.rs
+++ b/energy-integration/fees-collector/src/lib.rs
@@ -37,8 +37,10 @@ pub trait FeesCollector:
 
         let caller = self.blockchain().get_caller();
         let rewards = self.claim_multi(&caller, Self::collect_accumulated_fees_for_week);
-        self.send().direct_multi(&caller, &rewards);
-
+        if !rewards.is_empty() {
+            self.send().direct_multi(&caller, &rewards);
+        }
+        
         rewards
     }
 


### PR DESCRIPTION
Small fix to cover the case of having no rewards given on first claim.