### PR TITLE
Optimize token operations

### DIFF
--- a/common/modules/locking_module/Cargo.toml
+++ b/common/modules/locking_module/Cargo.toml
@@ -5,10 +5,13 @@ authors = [ "Dorin Iancu <dorin.iancu@elrond.com>" ]
 edition = "2018"
 
 [lib]
-path = "src/locking_module.rs"
+path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
 version = "0.34.0"
 
 [dependencies.simple-lock]
 path = "../../../locked-asset/simple-lock"
+
+[dependencies.simple-lock-energy]
+path = "../../../locked-asset/simple-lock-energy"

--- a/common/modules/locking_module/src/lib.rs
+++ b/common/modules/locking_module/src/lib.rs
@@ -1,0 +1,4 @@
+#![no_std]
+
+pub mod lock_with_energy_module;
+pub mod locking_module;

--- a/common/modules/locking_module/src/lock_with_energy_module.rs
+++ b/common/modules/locking_module/src/lock_with_energy_module.rs
@@ -1,0 +1,56 @@
+elrond_wasm::imports!();
+
+use simple_lock_energy::virtual_lock::ProxyTrait as _;
+
+#[elrond_wasm::module]
+pub trait LockWithEnergyModule {
+    #[only_owner]
+    #[endpoint(setLockingScAddress)]
+    fn set_locking_sc_address(&self, new_address: ManagedAddress) {
+        require!(
+            self.blockchain().is_smart_contract(&new_address),
+            "Invalid SC Address"
+        );
+
+        self.locking_sc_address().set(&new_address);
+    }
+
+    #[only_owner]
+    #[endpoint(setLockEpochs)]
+    fn set_lock_epochs(&self, lock_epochs: u64) {
+        self.lock_epochs().set(lock_epochs);
+    }
+
+    fn lock_virtual(
+        &self,
+        token_id: TokenIdentifier,
+        amount: BigUint,
+        dest_address: ManagedAddress,
+    ) -> EsdtTokenPayment {
+        let lock_epochs = self.lock_epochs().get();
+        let mut proxy_instance = self.get_locking_sc_proxy_instance();
+
+        proxy_instance
+            .lock_virtual(token_id, amount, lock_epochs, dest_address)
+            .execute_on_dest_context()
+    }
+
+    fn get_locking_sc_proxy_instance(&self) -> simple_lock_energy::Proxy<Self::Api> {
+        let locking_sc_address = self.locking_sc_address().get();
+        self.locking_sc_proxy_obj(locking_sc_address)
+    }
+
+    #[proxy]
+    fn locking_sc_proxy_obj(
+        &self,
+        sc_address: ManagedAddress,
+    ) -> simple_lock_energy::Proxy<Self::Api>;
+
+    #[view(getLockingScAddress)]
+    #[storage_mapper("lockingScAddress")]
+    fn locking_sc_address(&self) -> SingleValueMapper<ManagedAddress>;
+
+    #[view(getLockEpochs)]
+    #[storage_mapper("lockEpochs")]
+    fn lock_epochs(&self) -> SingleValueMapper<u64>;
+}

--- a/common/modules/locking_module/src/locking_module.rs
+++ b/common/modules/locking_module/src/locking_module.rs
@@ -1,5 +1,3 @@
-#![no_std]
-
 elrond_wasm::imports!();
 
 #[elrond_wasm::module]
@@ -18,7 +16,7 @@ pub trait LockingModule {
     #[only_owner]
     #[endpoint(setUnlockEpoch)]
     fn set_unlock_epoch(&self, new_epoch: u64) {
-        self.unlock_epoch().set(&new_epoch);
+        self.unlock_epoch().set(new_epoch);
     }
 
     #[inline]

--- a/dex/farm-with-locked-rewards/Cargo.toml
+++ b/dex/farm-with-locked-rewards/Cargo.toml
@@ -50,9 +50,6 @@ path = "../../common/modules/sc_whitelist_module"
 [dependencies.farm]
 path = "../farm"
 
-[dependencies.pair]
-path = "../pair"
-
 [dependencies.common_structs]
 path = "../../common/common_structs"
 
@@ -68,14 +65,8 @@ path = "../../energy-integration/common-modules/week-timekeeping"
 [dependencies.weekly-rewards-splitting]
 path = "../../energy-integration/common-modules/weekly-rewards-splitting"
 
-[dependencies.simple-lock]
-path = "../../locked-asset/simple-lock"
-
 [dependencies.simple-lock-energy]
 path = "../../locked-asset/simple-lock-energy"
-
-[dependencies.factory]
-path = "../../locked-asset/factory"
 
 [dependencies.energy-query]
 path = "../../energy-integration/common-modules/energy-query"
@@ -94,3 +85,6 @@ num-bigint = "0.4.2"
 
 [dev-dependencies.energy-factory-mock]
 path = "../../energy-integration/energy-factory-mock"
+
+[dev-dependencies.simple-lock]
+path = "../../locked-asset/simple-lock"

--- a/dex/farm-with-locked-rewards/tests/farm_with_locked_rewards_setup/mod.rs
+++ b/dex/farm-with-locked-rewards/tests/farm_with_locked_rewards_setup/mod.rs
@@ -19,7 +19,7 @@ use energy_query::{Energy, EnergyQueryModule};
 use farm_boosted_yields::FarmBoostedYieldsModule;
 use farm_token::FarmTokenModule;
 use farm_with_locked_rewards::Farm;
-use locking_module::LockingModule;
+use locking_module::lock_with_energy_module::LockWithEnergyModule;
 use pausable::{PausableModule, State};
 use sc_whitelist_module::SCWhitelistModule;
 use simple_lock::locked_token::LockedTokenModule;
@@ -151,7 +151,7 @@ where
                 sc.set_locking_sc_address(managed_address!(
                     simple_lock_energy_wrapper.address_ref()
                 ));
-                sc.set_unlock_epoch(EPOCHS_IN_YEAR);
+                sc.set_lock_epochs(EPOCHS_IN_YEAR);
 
                 // sc.base_asset_token_id(managed_token_id!(REWARD_TOKEN_ID));
 
@@ -224,6 +224,13 @@ where
             FARMING_TOKEN_ID,
             &rust_biguint!(FARMING_TOKEN_BALANCE),
         );
+
+        b_mock
+            .execute_tx(&owner, &simple_lock_energy_wrapper, &rust_zero, |sc| {
+                sc.sc_whitelist_addresses()
+                    .add(&managed_address!(farm_wrapper.address_ref()));
+            })
+            .assert_ok();
 
         FarmSetup {
             b_mock,

--- a/dex/farm-with-locked-rewards/wasm/src/lib.rs
+++ b/dex/farm-with-locked-rewards/wasm/src/lib.rs
@@ -32,6 +32,7 @@ elrond_wasm_node::wasm_endpoints! {
         getLastGlobalActiveWeek
         getLastGlobalUpdateWeek
         getLastRewardBlockNonce
+        getLockEpochs
         getLockingScAddress
         getMinimumFarmingEpoch
         getPairContractManagedAddress
@@ -45,7 +46,6 @@ elrond_wasm_node::wasm_endpoints! {
         getTotalEnergyForWeek
         getTotalLockedTokensForWeek
         getTotalRewardsForWeek
-        getUnlockEpoch
         getUserEnergyForWeek
         isSCAddressWhitelisted
         mergeFarmTokens
@@ -57,9 +57,9 @@ elrond_wasm_node::wasm_endpoints! {
         resume
         setBoostedYieldsRewardsPercentage
         setEnergyFactoryAddress
+        setLockEpochs
         setLockingScAddress
         setPerBlockRewardAmount
-        setUnlockEpoch
         set_burn_gas_limit
         set_minimum_farming_epochs
         set_penalty_percent

--- a/dex/price-discovery/src/lib.rs
+++ b/dex/price-discovery/src/lib.rs
@@ -20,7 +20,7 @@ const MAX_TOKEN_DECIMALS: u32 = 18;
 pub trait PriceDiscovery:
     common_storage::CommonStorageModule
     + events::EventsModule
-    + locking_module::LockingModule
+    + locking_module::locking_module::LockingModule
     + phase::PhaseModule
     + redeem_token::RedeemTokenModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule

--- a/locked-asset/simple-lock-energy/Cargo.toml
+++ b/locked-asset/simple-lock-energy/Cargo.toml
@@ -17,6 +17,9 @@ path = "../../common/common_structs"
 [dependencies.utils]
 path = "../../common/modules/utils"
 
+[dependencies.sc_whitelist_module]
+path = "../../common/modules/sc_whitelist_module"
+
 [dependencies.mergeable]
 path = "../../common/traits/mergeable"
 

--- a/locked-asset/simple-lock-energy/src/lib.rs
+++ b/locked-asset/simple-lock-energy/src/lib.rs
@@ -11,6 +11,7 @@ pub mod migration;
 pub mod token_merging;
 pub mod token_whitelist;
 pub mod unlock_with_penalty;
+pub mod virtual_lock;
 
 use common_structs::Epoch;
 use mergeable::Mergeable;
@@ -35,6 +36,8 @@ pub trait SimpleLockEnergy:
     + local_roles::LocalRolesModule
     + token_merging::TokenMergingModule
     + utils::UtilsModule
+    + virtual_lock::VirtualLockModule
+    + sc_whitelist_module::SCWhitelistModule
 {
     /// Args:
     /// - base_asset_token_id: The only token that is accepted for the lockTokens endpoint.
@@ -95,7 +98,7 @@ pub trait SimpleLockEnergy:
     #[endpoint(lockTokens)]
     fn lock_tokens_endpoint(
         &self,
-        lock_epochs: u64,
+        lock_epochs: Epoch,
         opt_destination: OptionalValue<ManagedAddress>,
     ) -> EsdtTokenPayment {
         self.require_not_paused();

--- a/locked-asset/simple-lock-energy/src/virtual_lock.rs
+++ b/locked-asset/simple-lock-energy/src/virtual_lock.rs
@@ -1,0 +1,60 @@
+elrond_wasm::imports!();
+
+use crate::energy::Energy;
+use common_structs::Epoch;
+
+#[elrond_wasm::module]
+pub trait VirtualLockModule:
+    simple_lock::basic_lock_unlock::BasicLockUnlock
+    + simple_lock::locked_token::LockedTokenModule
+    + simple_lock::token_attributes::TokenAttributesModule
+    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
+    + crate::token_whitelist::TokenWhitelistModule
+    + crate::energy::EnergyModule
+    + crate::lock_options::LockOptionsModule
+    + crate::events::EventsModule
+    + crate::migration::SimpleLockMigrationModule
+    + elrond_wasm_modules::pause::PauseModule
+    + utils::UtilsModule
+    + crate::extend_lock::ExtendLockModule
+    + sc_whitelist_module::SCWhitelistModule
+{
+    #[endpoint(lockVirtual)]
+    fn lock_virtual(
+        &self,
+        token_id: TokenIdentifier,
+        amount: BigUint,
+        lock_epochs: Epoch,
+        dest_address: ManagedAddress,
+    ) -> EsdtTokenPayment {
+        require!(
+            self.is_base_asset_token(&token_id),
+            "May only lock the base asset token"
+        );
+        require!(amount > 0, "Amount cannot be 0");
+        self.require_is_listed_lock_option(lock_epochs);
+
+        let caller = self.blockchain().get_caller();
+        self.require_sc_address_whitelisted(&caller);
+
+        let current_epoch = self.blockchain().get_block_epoch();
+        let unlock_epoch = self.unlock_epoch_to_start_of_month(current_epoch + lock_epochs);
+
+        let locked_tokens = self.update_energy(&dest_address, |energy: &mut Energy<Self::Api>| {
+            self.lock_base_asset(
+                EsdtTokenPayment::new(token_id, 0, amount),
+                unlock_epoch,
+                current_epoch,
+                energy,
+            )
+        });
+        self.send().direct_esdt(
+            &dest_address,
+            &locked_tokens.token_identifier,
+            locked_tokens.token_nonce,
+            &locked_tokens.amount,
+        );
+
+        locked_tokens
+    }
+}

--- a/locked-asset/simple-lock-energy/tests/virtual_lock_test.rs
+++ b/locked-asset/simple-lock-energy/tests/virtual_lock_test.rs
@@ -1,0 +1,72 @@
+mod simple_lock_energy_setup;
+
+use sc_whitelist_module::SCWhitelistModule;
+use simple_lock::locked_token::LockedTokenAttributes;
+use simple_lock_energy::virtual_lock::VirtualLockModule;
+use simple_lock_energy_setup::*;
+
+use elrond_wasm_debug::{
+    managed_address, managed_biguint, managed_token_id, managed_token_id_wrapped, rust_biguint,
+    DebugApi,
+};
+
+#[test]
+fn virtual_lock_test() {
+    let mut setup = SimpleLockEnergySetup::new(simple_lock_energy::contract_obj);
+    let first_user = setup.first_user.clone();
+    let second_user = setup.second_user.clone();
+
+    // not whitelisted
+    setup
+        .b_mock
+        .execute_tx(&first_user, &setup.sc_wrapper, &rust_biguint!(0), |sc| {
+            sc.lock_virtual(
+                managed_token_id!(BASE_ASSET_TOKEN_ID),
+                managed_biguint!(1_000),
+                LOCK_OPTIONS[0],
+                managed_address!(&second_user),
+            );
+        })
+        .assert_user_error("Item not whitelisted");
+
+    // wrong token
+    setup
+        .b_mock
+        .execute_tx(&first_user, &setup.sc_wrapper, &rust_biguint!(0), |sc| {
+            sc.lock_virtual(
+                managed_token_id!(b"RANDTOK-123456"),
+                managed_biguint!(1_000),
+                LOCK_OPTIONS[0],
+                managed_address!(&second_user),
+            );
+        })
+        .assert_user_error("May only lock the base asset token");
+
+    // lock virtual ok
+    setup
+        .b_mock
+        .execute_tx(&first_user, &setup.sc_wrapper, &rust_biguint!(0), |sc| {
+            sc.sc_whitelist_addresses()
+                .add(&managed_address!(&first_user));
+
+            sc.lock_virtual(
+                managed_token_id!(BASE_ASSET_TOKEN_ID),
+                managed_biguint!(1_000),
+                LOCK_OPTIONS[0],
+                managed_address!(&second_user),
+            );
+        })
+        .assert_ok();
+
+    setup.b_mock.check_nft_balance(
+        &second_user,
+        LOCKED_TOKEN_ID,
+        1,
+        &rust_biguint!(1_000),
+        Some(&LockedTokenAttributes::<DebugApi> {
+            original_token_id: managed_token_id_wrapped!(BASE_ASSET_TOKEN_ID),
+            original_token_nonce: 0,
+            unlock_epoch: 360,
+        }),
+    );
+}

--- a/locked-asset/simple-lock-energy/wasm/src/lib.rs
+++ b/locked-asset/simple-lock-energy/wasm/src/lib.rs
@@ -9,6 +9,7 @@ elrond_wasm_node::wasm_endpoints! {
     (
         callBack
         addLockOptions
+        addSCAddressToWhitelist
         getBaseAssetTokenId
         getEnergyAmountForUser
         getEnergyEntryForUser
@@ -20,12 +21,15 @@ elrond_wasm_node::wasm_endpoints! {
         getPenaltyAmount
         getPenaltyPercentage
         isPaused
+        isSCAddressWhitelisted
         issueLockedToken
         lockTokens
+        lockVirtual
         mergeTokens
         pause
         reduceLockPeriod
         removeLockOptions
+        removeSCAddressFromWhitelist
         setFeesBurnPercentage
         setFeesCollectorAddress
         setPenaltyPercentage


### PR DESCRIPTION
- for Farm with locked rewards, tokens are no longer minted, and then burned in simple-lock-energy. The farm SC will be added to a whitelist, which can lock tokens with simulated payment