### PR TITLE
Merge tokens unlock epoch fix

### DIFF
--- a/locked-asset/simple-lock-energy/src/token_merging.rs
+++ b/locked-asset/simple-lock-energy/src/token_merging.rs
@@ -12,7 +12,7 @@ use crate::{
 #[derive(Clone)]
 pub struct LockedAmountWeightAttributesPair<M: ManagedTypeApi> {
     pub token_amount: BigUint<M>,
-    pub token_unlock_fee: u64,
+    pub token_unlock_fee_percent: u64,
     pub attributes: LockedTokenAttributes<M>,
 }
 
@@ -29,14 +29,14 @@ impl<M: ManagedTypeApi> Mergeable<M> for LockedAmountWeightAttributesPair<M> {
         self.error_if_not_mergeable(&other);
 
         let unlock_fee: BigUint<M> = weighted_average(
-            &BigUint::from(self.token_unlock_fee),
-            &BigUint::from(self.attributes.unlock_epoch),
-            &BigUint::from(other.token_unlock_fee),
-            &BigUint::from(other.attributes.unlock_epoch),
+            &BigUint::from(self.token_unlock_fee_percent),
+            &self.token_amount.clone(),
+            &BigUint::from(other.token_unlock_fee_percent),
+            &other.token_amount.clone(),
         );
 
         self.token_amount += other.token_amount;
-        self.token_unlock_fee = unsafe { unlock_fee.to_u64().unwrap_unchecked() };
+        self.token_unlock_fee_percent = unsafe { unlock_fee.to_u64().unwrap_unchecked() };
     }
 }
 
@@ -111,12 +111,13 @@ pub trait TokenMergingModule:
             let lock_epochs_remaining = first_token_attributes.unlock_epoch - current_epoch;
             let mut output_pair = LockedAmountWeightAttributesPair {
                 token_amount: first_payment.amount,
-                token_unlock_fee: self.calculate_penalty_percentage_full_unlock(
+                token_unlock_fee_percent: self.calculate_penalty_percentage_full_unlock(
                     lock_epochs_remaining,
                     &penalty_percentage_struct,
                 ),
                 attributes: first_token_attributes,
             };
+
             for payment in &payments {
                 let attributes: LockedTokenAttributes<Self::Api> =
                     locked_token_mapper.get_token_attributes(payment.token_nonce);
@@ -129,18 +130,21 @@ pub trait TokenMergingModule:
                 locked_token_mapper.nft_burn(payment.token_nonce, &payment.amount);
 
                 let lock_epochs_remaining = attributes.unlock_epoch - current_epoch;
+
                 let amount_attr_pair = LockedAmountWeightAttributesPair {
                     token_amount: payment.amount,
-                    token_unlock_fee: self.calculate_penalty_percentage_full_unlock(
+                    token_unlock_fee_percent: self.calculate_penalty_percentage_full_unlock(
                         lock_epochs_remaining,
                         &penalty_percentage_struct,
                     ),
                     attributes,
                 };
+
                 output_pair.merge_with(amount_attr_pair.clone());
+
                 let penalty_percentage_struct = self.penalty_percentage().get();
                 output_pair.attributes.unlock_epoch = self.calculate_epoch_from_penalty_percentage(
-                    amount_attr_pair.token_unlock_fee,
+                    output_pair.token_unlock_fee_percent,
                     &penalty_percentage_struct,
                 );
             }

--- a/locked-asset/simple-lock-energy/tests/token_merging_test.rs
+++ b/locked-asset/simple-lock-energy/tests/token_merging_test.rs
@@ -59,9 +59,8 @@ fn token_merging_test() {
     assert_eq!(second_token_unlock_epoch, 720);
 
     // (400_000 * 360 + 100_000 * 720) / 500_000 = 432
-    // (400_000 * 4_000 + 100_000 * 6_000) / 10_000 = 4_400 (This is the fee)
     // -> start of month (upper) = 450
-    let expected_merged_token_unlock_epoch = 750;
+    let expected_merged_token_unlock_epoch = 450;
     setup.b_mock.check_nft_balance(
         &first_user,
         LOCKED_TOKEN_ID,


### PR DESCRIPTION
Fee percentage was not computed correctly which resulted in a wrong unlock epoch
