### PR TITLE
fixes

### DIFF
--- a/dex/farm/src/base_functions.rs
+++ b/dex/farm/src/base_functions.rs
@@ -186,11 +186,12 @@ pub trait BaseFunctionsModule:
     }
 
     fn check_claim_progress_for_merge(&self, caller: &ManagedAddress) {
-        let claim_progress = self.current_claim_progress(caller);
-        if !claim_progress.is_empty() {
+        let claim_progress_mapper = self.current_claim_progress(caller);
+        if !claim_progress_mapper.is_empty() {
             let current_week = self.get_current_week();
+            let claim_progress = claim_progress_mapper.get();
             require!(
-                claim_progress.get().week == current_week,
+                claim_progress.week == current_week,
                 "The user claim progress must be up to date."
             )
         }

--- a/locked-asset/proxy_dex/src/external_merging.rs
+++ b/locked-asset/proxy_dex/src/external_merging.rs
@@ -11,27 +11,39 @@ pub fn merge_locked_tokens_through_factory<M: CallTypeApi>(
     factory_address: ManagedAddress<M>,
     locked_tokens: PaymentsVec<M>,
 ) -> EsdtTokenPayment<M> {
-    let merge_endpoint_name = ManagedBuffer::new_from_bytes(FACTORY_MERGE_TOKENS_ENDPOINT_NAME);
-    let mut contract_call = ContractCall::<M, EsdtTokenPayment<M>>::new_with_esdt_payment(
+    merge_common(
+        original_caller,
         factory_address,
-        merge_endpoint_name,
+        FACTORY_MERGE_TOKENS_ENDPOINT_NAME,
         locked_tokens,
-    );
-    contract_call.push_endpoint_arg(&original_caller);
-
-    contract_call.execute_on_dest_context()
+    )
 }
 
 pub fn merge_farm_tokens_through_farm<M: CallTypeApi>(
+    original_caller: &ManagedAddress<M>,
     farm_address: ManagedAddress<M>,
     farm_tokens: PaymentsVec<M>,
 ) -> EsdtTokenPayment<M> {
-    let merge_endpoint_name = ManagedBuffer::new_from_bytes(FARM_MERGE_TOKENS_ENDPOINT_NAME);
-    let contract_call = ContractCall::<M, EsdtTokenPayment<M>>::new_with_esdt_payment(
+    merge_common(
+        original_caller,
         farm_address,
-        merge_endpoint_name,
+        FARM_MERGE_TOKENS_ENDPOINT_NAME,
         farm_tokens,
+    )
+}
+
+fn merge_common<M: CallTypeApi>(
+    original_caller: &ManagedAddress<M>,
+    sc_address: ManagedAddress<M>,
+    endpoint_name: &[u8],
+    tokens: PaymentsVec<M>,
+) -> EsdtTokenPayment<M> {
+    let mut contract_call = ContractCall::<M, EsdtTokenPayment<M>>::new_with_esdt_payment(
+        sc_address,
+        ManagedBuffer::new_from_bytes(endpoint_name),
+        tokens,
     );
+    contract_call.push_endpoint_arg(&original_caller);
 
     contract_call.execute_on_dest_context()
 }

--- a/locked-asset/proxy_dex/src/wrapped_farm_attributes.rs
+++ b/locked-asset/proxy_dex/src/wrapped_farm_attributes.rs
@@ -139,7 +139,8 @@ pub fn merge_wrapped_farm_tokens<M: CallTypeApi + StorageMapperApi>(
         )
     };
 
-    let merged_farm_tokens = merge_farm_tokens_through_farm(farm_address, farm_tokens_to_merge);
+    let merged_farm_tokens =
+        merge_farm_tokens_through_farm(original_caller, farm_address, farm_tokens_to_merge);
     let new_wrapped_farm_token_attributes = WrappedFarmTokenAttributes {
         farm_token: merged_farm_tokens,
         proxy_farming_token: merged_farming_tokens,

--- a/locked-asset/proxy_dex/tests/proxy_dex_test_setup/mod.rs
+++ b/locked-asset/proxy_dex/tests/proxy_dex_test_setup/mod.rs
@@ -111,6 +111,12 @@ where
             })
             .assert_ok();
 
+        b_mock
+            .execute_tx(&owner, &simple_lock_wrapper, &rust_zero, |sc| {
+                sc.add_sc_address_to_whitelist(managed_address!(proxy_wrapper.address_ref()));
+            })
+            .assert_ok();
+
         let user_balance = rust_biguint!(USER_BALANCE);
         b_mock.set_esdt_balance(&first_user, MEX_TOKEN_ID, &user_balance);
         b_mock.set_esdt_balance(&first_user, WEGLD_TOKEN_ID, &user_balance);

--- a/locked-asset/simple-lock-energy/src/fees.rs
+++ b/locked-asset/simple-lock-energy/src/fees.rs
@@ -30,6 +30,7 @@ pub trait FeesModule:
     + crate::events::EventsModule
     + crate::lock_options::LockOptionsModule
     + utils::UtilsModule
+    + sc_whitelist_module::SCWhitelistModule
 {
     fn burn_penalty(&self, token_id: TokenIdentifier, token_nonce: Nonce, fees_amount: &BigUint) {
         let fees_burn_percentage = self.fees_burn_percentage().get();

--- a/locked-asset/simple-lock-energy/src/unlock_with_penalty.rs
+++ b/locked-asset/simple-lock-energy/src/unlock_with_penalty.rs
@@ -24,6 +24,7 @@ pub trait UnlockWithPenaltyModule:
     + crate::penalty::LocalPenaltyModule
     + crate::fees::FeesModule
     + utils::UtilsModule
+    + sc_whitelist_module::SCWhitelistModule
 {
     /// Sets the percentage of fees that are burned. The rest are sent to the fees collector.
     /// Value between 0 and 10_000. 0 is also accepted.


### PR DESCRIPTION
- add original caller argument when merging farm tokens through proxy-dex
- use the wrapper method in `claim_multi` instead of accessing the raw mapper
- fix `claim_progress` logic when user tries to claim > 4 weeks