### PR TITLE
move rewards module to trait

### DIFF
--- a/common/modules/farm/farm_base_impl/src/base_traits_impl.rs
+++ b/common/modules/farm/farm_base_impl/src/base_traits_impl.rs
@@ -16,7 +16,6 @@ pub trait AllBaseFarmImplTraits =
         + permissions_module::PermissionsModule
         + pausable::PausableModule
         + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule;
-        
 
 pub trait FarmContract {
     type FarmSc: AllBaseFarmImplTraits;

--- a/common/modules/farm/farm_base_impl/src/base_traits_impl.rs
+++ b/common/modules/farm/farm_base_impl/src/base_traits_impl.rs
@@ -16,6 +16,7 @@ pub trait AllBaseFarmImplTraits =
         + permissions_module::PermissionsModule
         + pausable::PausableModule
         + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule;
+        
 
 pub trait FarmContract {
     type FarmSc: AllBaseFarmImplTraits;

--- a/common/modules/farm/farm_base_impl/src/claim_rewards.rs
+++ b/common/modules/farm/farm_base_impl/src/claim_rewards.rs
@@ -39,13 +39,14 @@ pub trait BaseClaimRewardsModule:
         payments: PaymentsVec<Self::Api>,
     ) -> InternalClaimRewardsResult<Self, FC::AttributesType> {
         let mut storage_cache = StorageCache::new(self);
+        self.validate_contract_state(storage_cache.contract_state, &storage_cache.farm_token_id);
+
         let claim_rewards_context = ClaimRewardsContext::<Self::Api, FC::AttributesType>::new(
             payments,
             &storage_cache.farm_token_id,
             self.blockchain(),
         );
 
-        self.validate_contract_state(storage_cache.contract_state, &storage_cache.farm_token_id);
         FC::generate_aggregated_rewards(self, &mut storage_cache);
 
         let farm_token_amount = &claim_rewards_context.first_farm_token.payment.amount;

--- a/common/modules/farm/farm_base_impl/src/compound_rewards.rs
+++ b/common/modules/farm/farm_base_impl/src/compound_rewards.rs
@@ -40,16 +40,16 @@ pub trait BaseCompoundRewardsModule:
         payments: PaymentsVec<Self::Api>,
     ) -> InternalCompoundRewardsResult<Self, FC::AttributesType> {
         let mut storage_cache = StorageCache::new(self);
-        let compound_rewards_context = CompoundRewardsContext::<Self::Api, FC::AttributesType>::new(
-            payments,
-            &storage_cache.farm_token_id,
-            self.blockchain(),
-        );
-
         self.validate_contract_state(storage_cache.contract_state, &storage_cache.farm_token_id);
         require!(
             storage_cache.farming_token_id == storage_cache.reward_token_id,
             ERROR_DIFFERENT_TOKEN_IDS
+        );
+
+        let compound_rewards_context = CompoundRewardsContext::<Self::Api, FC::AttributesType>::new(
+            payments,
+            &storage_cache.farm_token_id,
+            self.blockchain(),
         );
 
         FC::generate_aggregated_rewards(self, &mut storage_cache);

--- a/common/modules/farm/farm_base_impl/src/enter_farm.rs
+++ b/common/modules/farm/farm_base_impl/src/enter_farm.rs
@@ -38,13 +38,14 @@ pub trait BaseEnterFarmModule:
         payments: PaymentsVec<Self::Api>,
     ) -> InternalEnterFarmResult<Self, FC::AttributesType> {
         let mut storage_cache = StorageCache::new(self);
+        self.validate_contract_state(storage_cache.contract_state, &storage_cache.farm_token_id);
+
         let enter_farm_context = EnterFarmContext::new(
             payments,
             &storage_cache.farming_token_id,
             &storage_cache.farm_token_id,
         );
 
-        self.validate_contract_state(storage_cache.contract_state, &storage_cache.farm_token_id);
         FC::generate_aggregated_rewards(self, &mut storage_cache);
 
         let reward = if !enter_farm_context.additional_farm_tokens.is_empty() {

--- a/common/modules/farm/farm_base_impl/src/exit_farm.rs
+++ b/common/modules/farm/farm_base_impl/src/exit_farm.rs
@@ -38,13 +38,14 @@ pub trait BaseExitFarmModule:
         payment: EsdtTokenPayment<Self::Api>,
     ) -> InternalExitFarmResult<Self, FC::AttributesType> {
         let mut storage_cache = StorageCache::new(self);
+        self.validate_contract_state(storage_cache.contract_state, &storage_cache.farm_token_id);
+
         let exit_farm_context = ExitFarmContext::<Self::Api, FC::AttributesType>::new(
             payment,
             &storage_cache.farm_token_id,
             self.blockchain(),
         );
 
-        self.validate_contract_state(storage_cache.contract_state, &storage_cache.farm_token_id);
         FC::generate_aggregated_rewards(self, &mut storage_cache);
 
         let farm_token_amount = &exit_farm_context.farm_token.payment.amount;

--- a/common/modules/farm/rewards/src/rewards.rs
+++ b/common/modules/farm/rewards/src/rewards.rs
@@ -1,54 +1,11 @@
 #![no_std]
 
 elrond_wasm::imports!();
-elrond_wasm::derive_imports!();
-
-use common_structs::Nonce;
 
 #[elrond_wasm::module]
 pub trait RewardsModule:
-    config::ConfigModule
-    + farm_token::FarmTokenModule
-    + pausable::PausableModule
-    + permissions_module::PermissionsModule
-    + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
+    config::ConfigModule + pausable::PausableModule + permissions_module::PermissionsModule
 {
-    fn calculate_per_block_rewards(
-        &self,
-        current_block_nonce: Nonce,
-        last_reward_block_nonce: Nonce,
-    ) -> BigUint {
-        if current_block_nonce <= last_reward_block_nonce || !self.produces_per_block_rewards() {
-            return BigUint::zero();
-        }
-
-        let per_block_reward = self.per_block_reward_amount().get();
-        let block_nonce_diff = current_block_nonce - last_reward_block_nonce;
-
-        per_block_reward * block_nonce_diff
-    }
-
-    fn mint_per_block_rewards<MintFunction: Fn(&Self, &TokenIdentifier, &BigUint)>(
-        &self,
-        token_id: &TokenIdentifier,
-        mint_function: MintFunction,
-    ) -> BigUint {
-        let current_block_nonce = self.blockchain().get_block_nonce();
-        let last_reward_nonce = self.last_reward_block_nonce().get();
-        if current_block_nonce > last_reward_nonce {
-            let to_mint = self.calculate_per_block_rewards(current_block_nonce, last_reward_nonce);
-            if to_mint != 0 {
-                mint_function(self, token_id, &to_mint);
-            }
-
-            self.last_reward_block_nonce().set(current_block_nonce);
-
-            to_mint
-        } else {
-            BigUint::zero()
-        }
-    }
-
     fn start_produce_rewards(&self) {
         require!(
             self.per_block_reward_amount().get() != 0u64,

--- a/dex/farm-with-locked-rewards/src/lib.rs
+++ b/dex/farm-with-locked-rewards/src/lib.rs
@@ -249,9 +249,7 @@ where
         sc: &Self::FarmSc,
         storage_cache: &mut StorageCache<Self::FarmSc>,
     ) {
-        let total_reward =
-            sc.mint_per_block_rewards(&storage_cache.reward_token_id, Self::mint_rewards);
-
+        let total_reward = Self::mint_per_block_rewards(sc, &storage_cache.reward_token_id);
         if total_reward > 0u64 {
             storage_cache.reward_reserve += &total_reward;
             let split_rewards = sc.take_reward_slice(total_reward);

--- a/dex/farm/src/base_functions.rs
+++ b/dex/farm/src/base_functions.rs
@@ -238,9 +238,7 @@ where
         sc: &Self::FarmSc,
         storage_cache: &mut StorageCache<Self::FarmSc>,
     ) {
-        let total_reward =
-            sc.mint_per_block_rewards(&storage_cache.reward_token_id, Self::mint_rewards);
-
+        let total_reward = Self::mint_per_block_rewards(sc, &storage_cache.reward_token_id);
         if total_reward > 0u64 {
             storage_cache.reward_reserve += &total_reward;
             let split_rewards = sc.take_reward_slice(total_reward);


### PR DESCRIPTION
- move per block rewards calculation functions to the `FarmContract` trait, also removing the old `MintFunction` lambda argument in the process
- move contract state validation to the start of the function for the base farm implementations