### PR TITLE
Fix update user energy on claim rewards

### DIFF
--- a/common/modules/locking_module/src/lock_with_energy_module.rs
+++ b/common/modules/locking_module/src/lock_with_energy_module.rs
@@ -26,12 +26,13 @@ pub trait LockWithEnergyModule {
         token_id: TokenIdentifier,
         amount: BigUint,
         dest_address: ManagedAddress,
+        energy_address: ManagedAddress,
     ) -> EsdtTokenPayment {
         let lock_epochs = self.lock_epochs().get();
         let mut proxy_instance = self.get_locking_sc_proxy_instance();
 
         proxy_instance
-            .lock_virtual(token_id, amount, lock_epochs, dest_address)
+            .lock_virtual(token_id, amount, lock_epochs, dest_address, energy_address)
             .execute_on_dest_context()
     }
 

--- a/dex/farm-with-locked-rewards/src/lib.rs
+++ b/dex/farm-with-locked-rewards/src/lib.rs
@@ -120,7 +120,7 @@ pub trait Farm:
         let locked_rewards_payment = self.send_to_lock_contract_non_zero(
             rewards_payment.token_identifier,
             rewards_payment.amount,
-            caller.clone(),
+            caller,
             orig_caller.clone(),
         );
 

--- a/dex/farm-with-locked-rewards/src/lib.rs
+++ b/dex/farm-with-locked-rewards/src/lib.rs
@@ -120,7 +120,8 @@ pub trait Farm:
         let locked_rewards_payment = self.send_to_lock_contract_non_zero(
             rewards_payment.token_identifier,
             rewards_payment.amount,
-            caller,
+            caller.clone(),
+            orig_caller.clone(),
         );
 
         self.emit_claim_rewards_event::<_, FarmTokenAttributes<Self::Api>>(
@@ -186,6 +187,7 @@ pub trait Farm:
             rewards.token_identifier.clone(),
             rewards.amount.clone(),
             caller,
+            orig_caller.clone(),
         );
 
         if remaining_farm_payment.amount == 0 {
@@ -271,12 +273,13 @@ pub trait Farm:
         token_id: TokenIdentifier,
         amount: BigUint,
         destination_address: ManagedAddress,
+        energy_address: ManagedAddress,
     ) -> EsdtTokenPayment {
         if amount == 0 {
             return EsdtTokenPayment::new(token_id, 0, amount);
         }
 
-        self.lock_virtual(token_id, amount, destination_address)
+        self.lock_virtual(token_id, amount, destination_address, energy_address)
     }
 
     fn get_orig_caller_from_opt(

--- a/locked-asset/energy-factory/src/virtual_lock.rs
+++ b/locked-asset/energy-factory/src/virtual_lock.rs
@@ -26,6 +26,7 @@ pub trait VirtualLockModule:
         amount: BigUint,
         lock_epochs: Epoch,
         dest_address: ManagedAddress,
+        energy_address: ManagedAddress,
     ) -> EsdtTokenPayment {
         require!(
             self.is_base_asset_token(&token_id),
@@ -40,14 +41,15 @@ pub trait VirtualLockModule:
         let current_epoch = self.blockchain().get_block_epoch();
         let unlock_epoch = self.unlock_epoch_to_start_of_month(current_epoch + lock_epochs);
 
-        let locked_tokens = self.update_energy(&dest_address, |energy: &mut Energy<Self::Api>| {
-            self.lock_base_asset(
-                EsdtTokenPayment::new(token_id, 0, amount),
-                unlock_epoch,
-                current_epoch,
-                energy,
-            )
-        });
+        let locked_tokens =
+            self.update_energy(&energy_address, |energy: &mut Energy<Self::Api>| {
+                self.lock_base_asset(
+                    EsdtTokenPayment::new(token_id, 0, amount),
+                    unlock_epoch,
+                    current_epoch,
+                    energy,
+                )
+            });
         self.send().direct_esdt(
             &dest_address,
             &locked_tokens.token_identifier,

--- a/locked-asset/energy-factory/tests/virtual_lock_test.rs
+++ b/locked-asset/energy-factory/tests/virtual_lock_test.rs
@@ -25,6 +25,7 @@ fn virtual_lock_test() {
                 managed_biguint!(1_000),
                 LOCK_OPTIONS[0],
                 managed_address!(&second_user),
+                managed_address!(&second_user),
             );
         })
         .assert_user_error("Item not whitelisted");
@@ -37,6 +38,7 @@ fn virtual_lock_test() {
                 managed_token_id!(b"RANDTOK-123456"),
                 managed_biguint!(1_000),
                 LOCK_OPTIONS[0],
+                managed_address!(&second_user),
                 managed_address!(&second_user),
             );
         })
@@ -53,6 +55,7 @@ fn virtual_lock_test() {
                 managed_token_id!(BASE_ASSET_TOKEN_ID),
                 managed_biguint!(1_000),
                 LOCK_OPTIONS[0],
+                managed_address!(&second_user),
                 managed_address!(&second_user),
             );
         })

--- a/locked-asset/proxy_dex/Cargo.toml
+++ b/locked-asset/proxy_dex/Cargo.toml
@@ -20,6 +20,12 @@ path = "../../dex/pair"
 [dependencies.farm]
 path = "../../dex/farm"
 
+[dependencies.farm-with-locked-rewards]
+path = "../../dex/farm-with-locked-rewards"
+
+[dependencies.locking_module]
+path = "../../common/modules/locking_module"
+
 [dependencies.token_merge_helper]
 path = "../../common/modules/token_merge_helper"
 

--- a/locked-asset/proxy_dex/tests/proxy_dex_test_setup/mod.rs
+++ b/locked-asset/proxy_dex/tests/proxy_dex_test_setup/mod.rs
@@ -231,6 +231,12 @@ where
     }
 }
 
+pub fn to_rust_biguint(
+    managed_biguint: elrond_wasm::types::BigUint<DebugApi>,
+) -> num_bigint::BigUint {
+    num_bigint::BigUint::from_bytes_be(managed_biguint.to_bytes_be().as_slice())
+}
+
 fn setup_pair<PairObjBuilder>(
     b_mock: &mut BlockchainStateWrapper,
     owner: &Address,

--- a/locked-asset/proxy_dex/tests/proxy_dex_test_setup/mod.rs
+++ b/locked-asset/proxy_dex/tests/proxy_dex_test_setup/mod.rs
@@ -15,6 +15,8 @@ use energy_factory::SimpleLockEnergy;
 use farm::Farm;
 use farm_boosted_yields::FarmBoostedYieldsModule;
 use farm_token::FarmTokenModule;
+use farm_with_locked_rewards::Farm as FarmLocked;
+use locking_module::lock_with_energy_module::LockWithEnergyModule;
 use pair::{config::ConfigModule as OtherConfigModule, safe_price::SafePriceModule, Pair};
 use pausable::{PausableModule, State};
 use proxy_dex::{proxy_common::ProxyCommonModule, sc_whitelist::ScWhitelistModule, ProxyDexImpl};
@@ -32,6 +34,7 @@ pub static LP_TOKEN_ID: &[u8] = b"LPTOK-123456";
 
 // Farm
 pub static FARM_TOKEN_ID: &[u8] = b"FARM-123456";
+pub static FARM_LOCKED_TOKEN_ID: &[u8] = b"FARML-123456";
 pub const DIVISION_SAFETY_CONSTANT: u64 = 1_000_000_000_000_000_000;
 pub const PER_BLOCK_REWARD_AMOUNT: u64 = 5_000;
 pub const USER_REWARDS_BASE_CONST: u64 = 10;
@@ -51,11 +54,17 @@ pub const FEES_BURN_PERCENTAGE: u16 = 10_000; // 100%
 pub static WRAPPED_LP_TOKEN_ID: &[u8] = b"WPLP-123456";
 pub static WRAPPED_FARM_TOKEN_ID: &[u8] = b"WPFARM-123456";
 
-pub struct ProxySetup<ProxyObjBuilder, PairObjBuilder, FarmObjBuilder, SimpleLockObjBuilder>
-where
+pub struct ProxySetup<
+    ProxyObjBuilder,
+    PairObjBuilder,
+    FarmObjBuilder,
+    FarmLockedObjBuilder,
+    SimpleLockObjBuilder,
+> where
     ProxyObjBuilder: 'static + Copy + Fn() -> proxy_dex::ContractObj<DebugApi>,
     PairObjBuilder: 'static + Copy + Fn() -> pair::ContractObj<DebugApi>,
     FarmObjBuilder: 'static + Copy + Fn() -> farm::ContractObj<DebugApi>,
+    FarmLockedObjBuilder: 'static + Copy + Fn() -> farm_with_locked_rewards::ContractObj<DebugApi>,
     SimpleLockObjBuilder: 'static + Copy + Fn() -> energy_factory::ContractObj<DebugApi>,
 {
     pub b_mock: BlockchainStateWrapper,
@@ -65,22 +74,38 @@ where
     pub proxy_wrapper: ContractObjWrapper<proxy_dex::ContractObj<DebugApi>, ProxyObjBuilder>,
     pub pair_wrapper: ContractObjWrapper<pair::ContractObj<DebugApi>, PairObjBuilder>,
     pub farm_wrapper: ContractObjWrapper<farm::ContractObj<DebugApi>, FarmObjBuilder>,
+    pub farm_locked_wrapper:
+        ContractObjWrapper<farm_with_locked_rewards::ContractObj<DebugApi>, FarmLockedObjBuilder>,
     pub simple_lock_wrapper:
         ContractObjWrapper<energy_factory::ContractObj<DebugApi>, SimpleLockObjBuilder>,
 }
 
-impl<ProxyObjBuilder, PairObjBuilder, FarmObjBuilder, SimpleLockObjBuilder>
-    ProxySetup<ProxyObjBuilder, PairObjBuilder, FarmObjBuilder, SimpleLockObjBuilder>
+impl<
+        ProxyObjBuilder,
+        PairObjBuilder,
+        FarmObjBuilder,
+        FarmLockedObjBuilder,
+        SimpleLockObjBuilder,
+    >
+    ProxySetup<
+        ProxyObjBuilder,
+        PairObjBuilder,
+        FarmObjBuilder,
+        FarmLockedObjBuilder,
+        SimpleLockObjBuilder,
+    >
 where
     ProxyObjBuilder: 'static + Copy + Fn() -> proxy_dex::ContractObj<DebugApi>,
     PairObjBuilder: 'static + Copy + Fn() -> pair::ContractObj<DebugApi>,
     FarmObjBuilder: 'static + Copy + Fn() -> farm::ContractObj<DebugApi>,
+    FarmLockedObjBuilder: 'static + Copy + Fn() -> farm_with_locked_rewards::ContractObj<DebugApi>,
     SimpleLockObjBuilder: 'static + Copy + Fn() -> energy_factory::ContractObj<DebugApi>,
 {
     pub fn new(
         proxy_builder: ProxyObjBuilder,
         pair_builder: PairObjBuilder,
         farm_builder: FarmObjBuilder,
+        farm_locked_builder: FarmLockedObjBuilder,
         simple_lock_builder: SimpleLockObjBuilder,
     ) -> Self {
         let _ = DebugApi::dummy();
@@ -96,12 +121,19 @@ where
         let pair_wrapper = setup_pair(&mut b_mock, &owner, pair_builder);
         let farm_wrapper = setup_farm(&mut b_mock, &owner, farm_builder);
         let simple_lock_wrapper = setup_simple_lock(&mut b_mock, &owner, simple_lock_builder);
+        let farm_locked_wrapper = setup_farm_locked(
+            &mut b_mock,
+            &owner,
+            farm_locked_builder,
+            simple_lock_wrapper.address_ref(),
+        );
         let proxy_wrapper = setup_proxy(
             &mut b_mock,
             &owner,
             proxy_builder,
             pair_wrapper.address_ref(),
             farm_wrapper.address_ref(),
+            farm_locked_wrapper.address_ref(),
             simple_lock_wrapper.address_ref(),
         );
 
@@ -110,10 +142,20 @@ where
                 sc.add_sc_address_to_whitelist(managed_address!(proxy_wrapper.address_ref()));
             })
             .assert_ok();
-
+        b_mock
+            .execute_tx(&owner, &farm_locked_wrapper, &rust_zero, |sc| {
+                sc.add_sc_address_to_whitelist(managed_address!(proxy_wrapper.address_ref()));
+            })
+            .assert_ok();
         b_mock
             .execute_tx(&owner, &simple_lock_wrapper, &rust_zero, |sc| {
                 sc.add_sc_address_to_whitelist(managed_address!(proxy_wrapper.address_ref()));
+            })
+            .assert_ok();
+
+        b_mock
+            .execute_tx(&owner, &simple_lock_wrapper, &rust_zero, |sc| {
+                sc.add_sc_address_to_whitelist(managed_address!(farm_locked_wrapper.address_ref()));
             })
             .assert_ok();
 
@@ -183,6 +225,7 @@ where
             proxy_wrapper,
             pair_wrapper,
             farm_wrapper,
+            farm_locked_wrapper,
             simple_lock_wrapper,
         }
     }
@@ -307,6 +350,88 @@ where
     farm_wrapper
 }
 
+fn setup_farm_locked<FarmLockedObjBuilder>(
+    b_mock: &mut BlockchainStateWrapper,
+    owner: &Address,
+    farm_builder: FarmLockedObjBuilder,
+    simple_lock_addr: &Address,
+) -> ContractObjWrapper<farm_with_locked_rewards::ContractObj<DebugApi>, FarmLockedObjBuilder>
+where
+    FarmLockedObjBuilder: 'static + Copy + Fn() -> farm_with_locked_rewards::ContractObj<DebugApi>,
+{
+    let rust_zero = rust_biguint!(0u64);
+    let farm_wrapper = b_mock.create_sc_account(
+        &rust_zero,
+        Some(&owner),
+        farm_builder,
+        "farm-with-locked-rewards.wasm",
+    );
+
+    b_mock
+        .execute_tx(owner, &farm_wrapper, &rust_zero, |sc| {
+            let reward_token_id = managed_token_id!(MEX_TOKEN_ID);
+            let farming_token_id = managed_token_id!(MEX_TOKEN_ID);
+            let division_safety_constant = managed_biguint!(DIVISION_SAFETY_CONSTANT);
+            let pair_address = managed_address!(&Address::zero());
+
+            sc.init(
+                reward_token_id,
+                farming_token_id,
+                division_safety_constant,
+                pair_address,
+                managed_address!(&owner),
+                MultiValueEncoded::new(),
+            );
+
+            let farm_token_id = managed_token_id!(FARM_LOCKED_TOKEN_ID);
+            sc.farm_token().set_token_id(farm_token_id);
+
+            sc.per_block_reward_amount()
+                .set(&managed_biguint!(PER_BLOCK_REWARD_AMOUNT));
+
+            sc.state().set(State::Active);
+            sc.produce_rewards_enabled().set(true);
+
+            sc.set_boosted_yields_factors(
+                managed_biguint!(USER_REWARDS_BASE_CONST),
+                managed_biguint!(USER_REWARDS_ENERGY_CONST),
+                managed_biguint!(USER_REWARDS_FARM_CONST),
+                managed_biguint!(MIN_ENERGY_AMOUNT_FOR_BOOSTED_YIELDS),
+                managed_biguint!(MIN_FARM_AMOUNT_FOR_BOOSTED_YIELDS),
+            );
+            sc.set_locking_sc_address(managed_address!(simple_lock_addr));
+            sc.set_lock_epochs(EPOCHS_IN_YEAR);
+        })
+        .assert_ok();
+
+    let farm_token_roles = [
+        EsdtLocalRole::NftCreate,
+        EsdtLocalRole::NftAddQuantity,
+        EsdtLocalRole::NftBurn,
+    ];
+    b_mock.set_esdt_local_roles(
+        farm_wrapper.address_ref(),
+        FARM_LOCKED_TOKEN_ID,
+        &farm_token_roles[..],
+    );
+
+    let farming_token_roles = [EsdtLocalRole::Burn];
+    b_mock.set_esdt_local_roles(
+        farm_wrapper.address_ref(),
+        MEX_TOKEN_ID,
+        &farming_token_roles[..],
+    );
+
+    let reward_token_roles = [EsdtLocalRole::Mint];
+    b_mock.set_esdt_local_roles(
+        farm_wrapper.address_ref(),
+        MEX_TOKEN_ID,
+        &reward_token_roles[..],
+    );
+
+    farm_wrapper
+}
+
 fn setup_simple_lock<SimpleLockObjBuilder>(
     b_mock: &mut BlockchainStateWrapper,
     owner: &Address,
@@ -377,6 +502,7 @@ fn setup_proxy<ProxyObjBuilder>(
     proxy_builder: ProxyObjBuilder,
     pair_addr: &Address,
     farm_addr: &Address,
+    farm_locked_addr: &Address,
     simple_lock_addr: &Address,
 ) -> ContractObjWrapper<proxy_dex::ContractObj<DebugApi>, ProxyObjBuilder>
 where
@@ -408,6 +534,8 @@ where
 
             sc.intermediated_pairs().insert(managed_address!(pair_addr));
             sc.intermediated_farms().insert(managed_address!(farm_addr));
+            sc.intermediated_farms()
+                .insert(managed_address!(farm_locked_addr));
         })
         .assert_ok();
 

--- a/locked-asset/proxy_dex/tests/proxy_farm_test.rs
+++ b/locked-asset/proxy_dex/tests/proxy_farm_test.rs
@@ -18,6 +18,7 @@ fn farm_proxy_actions_test() {
         proxy_dex::contract_obj,
         pair::contract_obj,
         farm::contract_obj,
+        farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
     );
     let first_user = setup.first_user.clone();
@@ -195,5 +196,107 @@ fn farm_proxy_actions_test() {
                 amount: managed_biguint!(USER_BALANCE),
             },
         }),
+    );
+}
+
+#[test]
+fn farm_proxy_claim_energy_test() {
+    let mut setup = ProxySetup::new(
+        proxy_dex::contract_obj,
+        pair::contract_obj,
+        farm::contract_obj,
+        farm_with_locked_rewards::contract_obj,
+        energy_factory::contract_obj,
+    );
+    let first_user = setup.first_user.clone();
+    let farm_locked_addr = setup.farm_locked_wrapper.address_ref().clone();
+
+    //////////////////////////////////////////// ENTER FARM /////////////////////////////////////
+
+    setup
+        .b_mock
+        .execute_esdt_transfer(
+            &first_user,
+            &setup.proxy_wrapper,
+            LOCKED_TOKEN_ID,
+            1,
+            &rust_biguint!(USER_BALANCE),
+            |sc| {
+                sc.enter_farm_proxy_endpoint(managed_address!(&farm_locked_addr));
+            },
+        )
+        .assert_ok();
+
+    // check user balance
+    setup.b_mock.check_nft_balance::<Empty>(
+        &first_user,
+        LOCKED_TOKEN_ID,
+        1,
+        &rust_biguint!(0),
+        None,
+    );
+    setup.b_mock.check_nft_balance(
+        &first_user,
+        WRAPPED_FARM_TOKEN_ID,
+        1,
+        &rust_biguint!(USER_BALANCE),
+        Some(&WrappedFarmTokenAttributes::<DebugApi> {
+            proxy_farming_token: EsdtTokenPayment {
+                token_identifier: managed_token_id!(LOCKED_TOKEN_ID),
+                token_nonce: 1,
+                amount: managed_biguint!(USER_BALANCE),
+            },
+            farm_token: EsdtTokenPayment {
+                token_identifier: managed_token_id!(FARM_LOCKED_TOKEN_ID),
+                token_nonce: 1,
+                amount: managed_biguint!(USER_BALANCE),
+            },
+        }),
+    );
+
+    // check proxy balance
+    setup
+        .b_mock
+        .check_nft_balance::<FarmTokenAttributes<DebugApi>>(
+            setup.proxy_wrapper.address_ref(),
+            FARM_LOCKED_TOKEN_ID,
+            1,
+            &rust_biguint!(USER_BALANCE),
+            None,
+        );
+
+    // check farm balance
+    setup.b_mock.check_esdt_balance(
+        setup.farm_locked_wrapper.address_ref(),
+        MEX_TOKEN_ID,
+        &rust_biguint!(USER_BALANCE),
+    );
+
+    setup.b_mock.set_block_nonce(100);
+
+    //////////////////////////////////////////// CLAIM REWARDS /////////////////////////////////////
+
+    // claim rewards with half position
+    setup
+        .b_mock
+        .execute_esdt_transfer(
+            &first_user,
+            &setup.proxy_wrapper,
+            WRAPPED_FARM_TOKEN_ID,
+            1,
+            &rust_biguint!(USER_BALANCE),
+            |sc| {
+                sc.claim_rewards_proxy(managed_address!(&farm_locked_addr));
+            },
+        )
+        .assert_ok();
+
+    // check user balance
+    setup.b_mock.check_nft_balance::<Empty>(
+        &first_user,
+        LOCKED_TOKEN_ID,
+        1,
+        &(rust_biguint!(PER_BLOCK_REWARD_AMOUNT) * 100u32),
+        None,
     );
 }

--- a/locked-asset/proxy_dex/tests/proxy_lp_test.rs
+++ b/locked-asset/proxy_dex/tests/proxy_lp_test.rs
@@ -18,6 +18,7 @@ fn setup_test() {
         proxy_dex::contract_obj,
         pair::contract_obj,
         farm::contract_obj,
+        farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
     );
 }
@@ -28,6 +29,7 @@ fn add_remove_liquidity_proxy_test() {
         proxy_dex::contract_obj,
         pair::contract_obj,
         farm::contract_obj,
+        farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
     );
     let first_user = setup.first_user.clone();
@@ -182,6 +184,7 @@ fn wrapped_lp_token_merge_test() {
         proxy_dex::contract_obj,
         pair::contract_obj,
         farm::contract_obj,
+        farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
     );
     let first_user = setup.first_user.clone();


### PR DESCRIPTION
- claim rewards from farms calls energy factory virtual_lock with caller as send tokens address and original_caller for energy update;
- this can ensure compatibility for proxy_dex if used with farms generating unlocked rewards

Signed-off-by: Claudiu Lataretu <claudiu.lataretu@gmail.com>