### PR TITLE
LKMEX Governance

### DIFF
--- a/energy-integration/governance-v2/Cargo.toml
+++ b/energy-integration/governance-v2/Cargo.toml
@@ -20,6 +20,8 @@ version = "=0.36.1"
 
 [dev-dependencies]
 num-bigint = "0.4.2"
+hex = "0.4"
+hex-literal = "0.3.4"
 
 [dev-dependencies.energy-factory-mock]
 path = "../energy-factory-mock"

--- a/energy-integration/governance-v2/meta/Cargo.toml
+++ b/energy-integration/governance-v2/meta/Cargo.toml
@@ -11,4 +11,4 @@ authors = [ "you",]
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "=0.36.1"
+version = "0.36.1"

--- a/energy-integration/governance-v2/meta/Cargo.toml
+++ b/energy-integration/governance-v2/meta/Cargo.toml
@@ -11,4 +11,4 @@ authors = [ "you",]
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.1"
+version = "=0.36.1"

--- a/energy-integration/governance-v2/src/lib.rs
+++ b/energy-integration/governance-v2/src/lib.rs
@@ -69,6 +69,7 @@ pub trait GovernanceV2:
     ///
     /// Returns the ID of the newly created proposal.
     #[endpoint]
+    #[only_owner]
     fn propose(
         &self,
         root_hash: ManagedByteArray<HASH_LENGTH>,

--- a/energy-integration/governance-v2/src/lib.rs
+++ b/energy-integration/governance-v2/src/lib.rs
@@ -359,14 +359,11 @@ pub trait GovernanceV2:
 
         for proof_item in proof {
             if BigUint::from(hash.as_managed_buffer()) < BigUint::from(proof_item.as_managed_buffer()) {
-                // sc_print!("going if {:x} - {:x}", hash, proof_item);
                 let mut tst = hash.as_managed_buffer().clone();
                 tst.append(proof_item.as_managed_buffer());
 
                 hash = self.crypto().sha256(tst);
             } else {
-                // sc_print!("going else {:x} - {:x}", hash, proof_item);
-
                 let mut tst = proof_item.as_managed_buffer().clone();
                 tst.append(hash.as_managed_buffer());
 

--- a/energy-integration/governance-v2/src/lib.rs
+++ b/energy-integration/governance-v2/src/lib.rs
@@ -8,7 +8,6 @@ pub mod proposal;
 pub mod proposal_storage;
 pub mod views;
 
-
 use proposal::*;
 use proposal_storage::VoteType;
 
@@ -140,7 +139,7 @@ pub trait GovernanceV2:
 
     /// Vote on a proposal. The voting power depends on the user's energy.
     #[endpoint]
-    fn vote(&self, proposal_id: ProposalId, vote: VoteType, power: BigUint<Self::Api>, proof: ArrayVec<ManagedByteArray<32>, 18>) {
+    fn vote(&self, proposal_id: ProposalId, vote: VoteType, power: BigUint<Self::Api>, proof: ArrayVec<ManagedByteArray<HASH_LENGTH>, PROOF_LENGTH>) {
         self.require_caller_not_self();
         self.require_valid_proposal_id(proposal_id);
         require!(
@@ -347,8 +346,8 @@ pub trait GovernanceV2:
 
         self.proposal_votes(proposal_id).clear();
     }
-    
-    fn verify_merkle_proof(&self, power: BigUint<Self::Api>, proof: ArrayVec<ManagedByteArray<HASH_LENGTH>, 18>, root_hash: ManagedByteArray<HASH_LENGTH>) -> bool {
+
+    fn verify_merkle_proof(&self, power: BigUint<Self::Api>, proof: ArrayVec<ManagedByteArray<HASH_LENGTH>, PROOF_LENGTH>, root_hash: ManagedByteArray<HASH_LENGTH>) -> bool {
         let caller = self.blockchain().get_caller().clone();
         let mut leaf_bytes = caller.as_managed_buffer().clone();
 

--- a/energy-integration/governance-v2/src/lib.rs
+++ b/energy-integration/governance-v2/src/lib.rs
@@ -189,6 +189,8 @@ pub trait GovernanceV2:
         
             }
         }
+        
+        let _ = self.user_voted_proposals(&voter).insert(proposal_id);
     }
 
     /// Queue a proposal for execution.
@@ -352,11 +354,9 @@ pub trait GovernanceV2:
         let mut leaf_bytes = caller.as_managed_buffer().clone();
 
         let p = power.to_bytes_be_buffer();
-
         leaf_bytes.append(&p);
 
         let mut hash = self.crypto().sha256(&leaf_bytes);
-
         for proof_item in proof {
             if BigUint::from(hash.as_managed_buffer()) < BigUint::from(proof_item.as_managed_buffer()) {
                 let mut tst = hash.as_managed_buffer().clone();

--- a/energy-integration/governance-v2/src/proposal.rs
+++ b/energy-integration/governance-v2/src/proposal.rs
@@ -1,6 +1,7 @@
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
+pub const HASH_LENGTH: usize = 32;
 pub const MAX_GOVERNANCE_PROPOSAL_ACTIONS: usize = 5;
 
 pub type ProposalId = usize;
@@ -63,4 +64,5 @@ pub struct GovernanceProposal<M: ManagedTypeApi> {
     pub proposer: ManagedAddress<M>,
     pub actions: ArrayVec<GovernanceAction<M>, MAX_GOVERNANCE_PROPOSAL_ACTIONS>,
     pub description: ManagedBuffer<M>,
+    pub root_hash: ManagedByteArray<M, HASH_LENGTH>,
 }

--- a/energy-integration/governance-v2/src/proposal.rs
+++ b/energy-integration/governance-v2/src/proposal.rs
@@ -2,6 +2,7 @@ elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
 pub const HASH_LENGTH: usize = 32;
+pub const PROOF_LENGTH: usize = 18;
 pub const MAX_GOVERNANCE_PROPOSAL_ACTIONS: usize = 5;
 
 pub type ProposalId = usize;

--- a/energy-integration/governance-v2/src/views.rs
+++ b/energy-integration/governance-v2/src/views.rs
@@ -1,8 +1,8 @@
 elrond_wasm::imports!();
 
-use crate::proposal::{
-    GovernanceAction, GovernanceProposalStatus, ProposalId, MAX_GOVERNANCE_PROPOSAL_ACTIONS,
-};
+use crate::{proposal::{
+    GovernanceAction, GovernanceProposalStatus, ProposalId, MAX_GOVERNANCE_PROPOSAL_ACTIONS, HASH_LENGTH
+}, proposal_storage::VoteType};
 
 #[elrond_wasm::module]
 pub trait ViewsModule:
@@ -59,6 +59,11 @@ pub trait ViewsModule:
         }
     }
 
+    #[view(getVoteStatus)]
+    fn get_vote_status(&self, proposal_id: ProposalId, address: ManagedAddress<Self::Api>) -> OptionalValue<VoteType> {
+        return OptionalValue::None;
+    }
+
     #[view(getProposer)]
     fn get_proposer(&self, proposal_id: ProposalId) -> OptionalValue<ManagedAddress> {
         if !self.proposal_exists(proposal_id) {
@@ -66,6 +71,15 @@ pub trait ViewsModule:
         }
 
         OptionalValue::Some(self.proposals().get(proposal_id).proposer)
+    }
+
+    #[view(getProposalRootHash)]
+    fn get_root_hash(&self, proposal_id: ProposalId) -> OptionalValue<ManagedByteArray<HASH_LENGTH>> {
+        if !self.proposal_exists(proposal_id) {
+            return OptionalValue::None;
+        }
+
+        OptionalValue::Some(self.proposals().get(proposal_id).root_hash)
     }
 
     #[view(getProposalDescription)]

--- a/energy-integration/governance-v2/src/views.rs
+++ b/energy-integration/governance-v2/src/views.rs
@@ -2,7 +2,7 @@ elrond_wasm::imports!();
 
 use crate::{proposal::{
     GovernanceAction, GovernanceProposalStatus, ProposalId, MAX_GOVERNANCE_PROPOSAL_ACTIONS, HASH_LENGTH
-}, proposal_storage::VoteType};
+}};
 
 #[elrond_wasm::module]
 pub trait ViewsModule:
@@ -59,9 +59,9 @@ pub trait ViewsModule:
         }
     }
 
-    #[view(getVoteStatus)]
-    fn get_vote_status(&self, proposal_id: ProposalId, address: ManagedAddress<Self::Api>) -> OptionalValue<VoteType> {
-        return OptionalValue::None;
+    #[view(userVotedProposal)]
+    fn user_voted_proposal(&self, proposal_id: ProposalId, address: ManagedAddress<Self::Api>) -> bool {
+        self.user_voted_proposals(&address).contains(&proposal_id)
     }
 
     #[view(getProposer)]

--- a/energy-integration/governance-v2/tests/gov_rust_test.rs
+++ b/energy-integration/governance-v2/tests/gov_rust_test.rs
@@ -1,7 +1,5 @@
 mod gov_test_setup;
 
-use elrond_wasm::{types::ManagedByteArray, arrayvec::ArrayVec};
-use elrond_wasm::hex_literal::hex;
 use elrond_wasm_debug::{managed_biguint, rust_biguint, DebugApi};
 use gov_test_setup::*;
 use governance_v2::{

--- a/energy-integration/governance-v2/tests/gov_test_setup/mod.rs
+++ b/energy-integration/governance-v2/tests/gov_test_setup/mod.rs
@@ -1,4 +1,4 @@
-use elrond_wasm::types::{Address, BigInt, EsdtTokenPayment, ManagedVec, MultiValueEncoded};
+use elrond_wasm::{types::{Address, BigInt, EsdtTokenPayment, ManagedVec, MultiValueEncoded, BigUint, ManagedByteArray}, arrayvec::ArrayVec};
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_buffer, managed_token_id, rust_biguint,
     testing_framework::{BlockchainStateWrapper, ContractObjWrapper},
@@ -19,6 +19,8 @@ pub const LOCKING_PERIOD_BLOCKS: u64 = 30;
 
 pub const USER_ENERGY: u64 = 1_000;
 pub const GAS_LIMIT: u64 = 1_000_000;
+
+pub const DUMMY_PROOF: ArrayVec<ManagedByteArray<DebugApi, 32>, 18> = ArrayVec::new_const();
 
 #[derive(Clone)]
 pub struct Payment {
@@ -160,28 +162,28 @@ where
     pub fn up_vote(&mut self, voter: &Address, proposal_id: usize) -> TxResult {
         self.b_mock
             .execute_tx(voter, &self.gov_wrapper, &rust_biguint!(0), |sc| {
-                sc.vote(proposal_id, VoteType::UpVote);
+                sc.vote(proposal_id, VoteType::UpVote, BigUint::from(managed_biguint!(0)), DUMMY_PROOF);
             })
     }
 
     pub fn down_vote(&mut self, voter: &Address, proposal_id: usize) -> TxResult {
         self.b_mock
             .execute_tx(voter, &self.gov_wrapper, &rust_biguint!(0), |sc| {
-                sc.vote(proposal_id, VoteType::DownVote);
+                sc.vote(proposal_id, VoteType::DownVote, BigUint::from(managed_biguint!(0)), DUMMY_PROOF);
             })
     }
 
     pub fn down_veto_vote(&mut self, voter: &Address, proposal_id: usize) -> TxResult {
         self.b_mock
             .execute_tx(voter, &self.gov_wrapper, &rust_biguint!(0), |sc| {
-                sc.vote(proposal_id, VoteType::DownVetoVote);
+                sc.vote(proposal_id, VoteType::DownVetoVote, BigUint::from(managed_biguint!(0)), DUMMY_PROOF);
             })
     }
 
     pub fn abstain_vote(&mut self, voter: &Address, proposal_id: usize) -> TxResult {
         self.b_mock
             .execute_tx(voter, &self.gov_wrapper, &rust_biguint!(0), |sc| {
-                sc.vote(proposal_id, VoteType::AbstainVote);
+                sc.vote(proposal_id, VoteType::AbstainVote, BigUint::from(managed_biguint!(0)), DUMMY_PROOF);
             })
     }
 

--- a/energy-integration/governance-v2/tests/gov_test_setup/mod.rs
+++ b/energy-integration/governance-v2/tests/gov_test_setup/mod.rs
@@ -10,17 +10,16 @@ use energy_query::Energy;
 use governance_v2::{
     configurable::ConfigurablePropertiesModule, proposal_storage::VoteType, GovernanceV2,
 };
+use elrond_wasm::hex_literal::hex;
 
 pub const MIN_ENERGY_FOR_PROPOSE: u64 = 500;
-pub const QUORUM: u64 = 1_500;
+pub const QUORUM: u64 = 217_433_990_694;
 pub const VOTING_DELAY_BLOCKS: u64 = 10;
 pub const VOTING_PERIOD_BLOCKS: u64 = 20;
 pub const LOCKING_PERIOD_BLOCKS: u64 = 30;
 
 pub const USER_ENERGY: u64 = 1_000;
 pub const GAS_LIMIT: u64 = 1_000_000;
-
-pub const DUMMY_PROOF: ArrayVec<ManagedByteArray<DebugApi, 32>, 18> = ArrayVec::new_const();
 
 #[derive(Clone)]
 pub struct Payment {
@@ -38,6 +37,9 @@ where
     pub first_user: Address,
     pub second_user: Address,
     pub third_user: Address,
+    pub first_merkle_user: Address,
+    pub second_merkle_user: Address,
+    pub third_merkle_user: Address,
     pub gov_wrapper: ContractObjWrapper<governance_v2::ContractObj<DebugApi>, GovBuilder>,
     pub current_block: u64,
 }
@@ -53,6 +55,10 @@ where
         let first_user = b_mock.create_user_account(&rust_zero);
         let second_user = b_mock.create_user_account(&rust_zero);
         let third_user = b_mock.create_user_account(&rust_zero);
+        let first_merkle_user = Address::from(&hex!("25ee243280fc6e740424a28fa40c795458943b475cd77f3778f9c8e0b4a1e7f8"));
+        let second_merkle_user = Address::from(&hex!("0d5acc0ee5a229ae549dad903fb7bcbc1f80b67198949f02fd611d25d41689cb"));
+        let third_merkle_user = Address::from(&hex!("190c55b8f27547244c65ad13cbbe7457d5fb90481f34b84160a1cf6e44e0875c"));
+        b_mock.create_user_account_fixed_address(&first_merkle_user, &rust_zero);
 
         // init energy factory
         let energy_factory_wrapper = b_mock.create_sc_account(
@@ -110,6 +116,9 @@ where
             first_user,
             second_user,
             third_user,
+            first_merkle_user,
+            second_merkle_user,
+            third_merkle_user,
             gov_wrapper,
             current_block: 10,
         }
@@ -117,6 +126,7 @@ where
 
     pub fn propose(
         &mut self,
+        root_hash: ManagedByteArray<DebugApi, 32>,
         proposer: &Address,
         dest_address: &Address,
         payments: Vec<Payment>,
@@ -153,37 +163,38 @@ where
                         .into(),
                 );
 
-                proposal_id = sc.propose(managed_buffer!(b"change quorum"), actions);
+                proposal_id = sc.propose(root_hash, managed_buffer!(b"change quorum"), actions);
             });
 
         (result, proposal_id)
     }
 
-    pub fn up_vote(&mut self, voter: &Address, proposal_id: usize) -> TxResult {
+    pub fn up_vote(&mut self, voter: &Address, power: &BigUint<DebugApi>, proof: &ArrayVec<ManagedByteArray<DebugApi, 32>, 18>, proposal_id: usize) -> TxResult {
         self.b_mock
             .execute_tx(voter, &self.gov_wrapper, &rust_biguint!(0), |sc| {
-                sc.vote(proposal_id, VoteType::UpVote, BigUint::from(managed_biguint!(0)), DUMMY_PROOF);
+                
+                sc.vote(proposal_id, VoteType::UpVote, power.clone(), proof.clone());
             })
     }
 
-    pub fn down_vote(&mut self, voter: &Address, proposal_id: usize) -> TxResult {
+    pub fn down_vote(&mut self, voter: &Address, power: &BigUint<DebugApi>, proof: &ArrayVec<ManagedByteArray<DebugApi, 32>, 18>, proposal_id: usize) -> TxResult {
         self.b_mock
             .execute_tx(voter, &self.gov_wrapper, &rust_biguint!(0), |sc| {
-                sc.vote(proposal_id, VoteType::DownVote, BigUint::from(managed_biguint!(0)), DUMMY_PROOF);
+                sc.vote(proposal_id, VoteType::DownVote, power.clone(), proof.clone());
             })
     }
 
-    pub fn down_veto_vote(&mut self, voter: &Address, proposal_id: usize) -> TxResult {
+    pub fn down_veto_vote(&mut self, voter: &Address, power: &BigUint<DebugApi>, proof: &ArrayVec<ManagedByteArray<DebugApi, 32>, 18>, proposal_id: usize) -> TxResult {
         self.b_mock
             .execute_tx(voter, &self.gov_wrapper, &rust_biguint!(0), |sc| {
-                sc.vote(proposal_id, VoteType::DownVetoVote, BigUint::from(managed_biguint!(0)), DUMMY_PROOF);
+                sc.vote(proposal_id, VoteType::DownVetoVote, power.clone(), proof.clone());
             })
     }
 
-    pub fn abstain_vote(&mut self, voter: &Address, proposal_id: usize) -> TxResult {
+    pub fn abstain_vote(&mut self, voter: &Address, power: &BigUint<DebugApi>, proof: &ArrayVec<ManagedByteArray<DebugApi, 32>, 18>, proposal_id: usize) -> TxResult {
         self.b_mock
             .execute_tx(voter, &self.gov_wrapper, &rust_biguint!(0), |sc| {
-                sc.vote(proposal_id, VoteType::AbstainVote, BigUint::from(managed_biguint!(0)), DUMMY_PROOF);
+                sc.vote(proposal_id, VoteType::AbstainVote, power.clone(), proof.clone());
             })
     }
 
@@ -245,5 +256,92 @@ where
     pub fn set_block_nonce(&mut self, block_nonce: u64) {
         self.current_block = block_nonce;
         self.b_mock.set_block_nonce(self.current_block);
+    }
+
+    pub fn first_merkle_proof(&self) -> ArrayVec<ManagedByteArray<DebugApi, 32>, 18> {
+        ArrayVec::from([
+            ManagedByteArray::from(&hex!("5e9e904152b2a06dafc26aa02b8c55b2ec3370cdf55b06b15fe8c94bc56e43fc")),
+            ManagedByteArray::from(&hex!("47aa547fa524519bc946d0883591e9d273a65b4a8f06a37baf170c707c4fb782")),
+            ManagedByteArray::from(&hex!("da05a587448779b9368680f0ee745b3ff2df1132e309a2de518aa9814cc25de8")),
+            ManagedByteArray::from(&hex!("14ae69620e727d8e899119ef7a1f04191f15f7c704c2673445510a1bbce7edb2")),
+            ManagedByteArray::from(&hex!("449e8beb9a901efc2815253a2ce416e3b98ff771fdfc9e35f4ce31004003e533")),
+            ManagedByteArray::from(&hex!("fdf33783f8de396173fd37b558213117bb2be3430d50b18eeb5da1af0b98fd66")),
+            ManagedByteArray::from(&hex!("889a7d403faae66ec51db6b0708d889ca277e2fd64f78e47612c07077df6eccc")),
+            ManagedByteArray::from(&hex!("5cc55493d05c9bf63431384f184e0cc6ab13c14509c3e9a64dc49b47e3821c6f")),
+            ManagedByteArray::from(&hex!("ca559e91dee09fccf8d3dbf9bda81f57d4094faecf2f9ac3a98e84b3f376c81c")),
+            ManagedByteArray::from(&hex!("781cf1316f87a336a7219095aa8b523a821d260ca0b7a7f94af5c769e17c8f82")),
+            ManagedByteArray::from(&hex!("5e97339ee010d2ae3ac54c38c7158e7a7ef4311f89b28b4634d0d35fd4097dc0")),
+            ManagedByteArray::from(&hex!("2c7b2103c3e48386a7eda174cec726c28ec6ce80466deaac49dbaf469f35d059")),
+            ManagedByteArray::from(&hex!("9b2ceb7809f078724efb71ea3542885c990985d41746d4cab7948928384c3a4c")),
+            ManagedByteArray::from(&hex!("b1f37e46c3f84a3c68804d62b26b7f035c90f344252d77fdeff2393793ae34d4")),
+            ManagedByteArray::from(&hex!("95ead464db14a9a65c3b9c5378cf927b76ff530ae0762dbb6456bfeb467f97b2")),
+            ManagedByteArray::from(&hex!("39e10ed734ddaa3098edc6300edeed2fce75780fc718140359b13c58045a1838")),
+            ManagedByteArray::from(&hex!("b36fbf7a645b24bab3eaca5c351985f6bbb95723b47db78171dd7d7f8883ecad")),
+            ManagedByteArray::from(&hex!("bffe20aa722c488465e18d10ac3abe3002603bbd4c535211d9bd9b34ce7259a1")),
+        ])
+    }
+
+    pub fn second_merkle_proof(&self) -> ArrayVec<ManagedByteArray<DebugApi, 32>, 18> {
+        ArrayVec::from([
+            ManagedByteArray::from(&hex!("b1d7a256ae6b35cce14497b3735d71dd205f099f1a035a7a5cb96e8bf5c32f31")),
+            ManagedByteArray::from(&hex!("81dc00d137001723d5654e3120d63601b08ca2b4b8dc41802476529e6d6ada9e")),
+            ManagedByteArray::from(&hex!("985e3554adfefea5d2c3f7c93d404fd547cfead9054ce313845656507037df40")),
+            ManagedByteArray::from(&hex!("14ae69620e727d8e899119ef7a1f04191f15f7c704c2673445510a1bbce7edb2")),
+            ManagedByteArray::from(&hex!("449e8beb9a901efc2815253a2ce416e3b98ff771fdfc9e35f4ce31004003e533")),
+            ManagedByteArray::from(&hex!("fdf33783f8de396173fd37b558213117bb2be3430d50b18eeb5da1af0b98fd66")),
+            ManagedByteArray::from(&hex!("889a7d403faae66ec51db6b0708d889ca277e2fd64f78e47612c07077df6eccc")),
+            ManagedByteArray::from(&hex!("5cc55493d05c9bf63431384f184e0cc6ab13c14509c3e9a64dc49b47e3821c6f")),
+            ManagedByteArray::from(&hex!("ca559e91dee09fccf8d3dbf9bda81f57d4094faecf2f9ac3a98e84b3f376c81c")),
+            ManagedByteArray::from(&hex!("781cf1316f87a336a7219095aa8b523a821d260ca0b7a7f94af5c769e17c8f82")),
+            ManagedByteArray::from(&hex!("5e97339ee010d2ae3ac54c38c7158e7a7ef4311f89b28b4634d0d35fd4097dc0")),
+            ManagedByteArray::from(&hex!("2c7b2103c3e48386a7eda174cec726c28ec6ce80466deaac49dbaf469f35d059")),
+            ManagedByteArray::from(&hex!("9b2ceb7809f078724efb71ea3542885c990985d41746d4cab7948928384c3a4c")),
+            ManagedByteArray::from(&hex!("b1f37e46c3f84a3c68804d62b26b7f035c90f344252d77fdeff2393793ae34d4")),
+            ManagedByteArray::from(&hex!("95ead464db14a9a65c3b9c5378cf927b76ff530ae0762dbb6456bfeb467f97b2")),
+            ManagedByteArray::from(&hex!("39e10ed734ddaa3098edc6300edeed2fce75780fc718140359b13c58045a1838")),
+            ManagedByteArray::from(&hex!("b36fbf7a645b24bab3eaca5c351985f6bbb95723b47db78171dd7d7f8883ecad")),
+            ManagedByteArray::from(&hex!("bffe20aa722c488465e18d10ac3abe3002603bbd4c535211d9bd9b34ce7259a1")),
+        ])
+    }
+
+    pub fn third_merkle_proof(&self) -> ArrayVec<ManagedByteArray<DebugApi, 32>, 18> {
+        ArrayVec::from([
+            ManagedByteArray::from(&hex!("aa68ae7eac4de3cc643717d33ab7d2e1b098788b127f298f23a34e8720ec609d")),
+            ManagedByteArray::from(&hex!("e3db2cf9f85b49279eba44b0f62ac2c6bcdf870f198b9484344634a58860ba2d")),
+            ManagedByteArray::from(&hex!("64468b8481d2c1737977e7382eaaa12c8072ee76fda33c3b6aaa193b38d4f1f2")),
+            ManagedByteArray::from(&hex!("6159dc0c80183e89221a36db3fedfabe38933d0db73c1156ad32d8caf0537085")),
+            ManagedByteArray::from(&hex!("449e8beb9a901efc2815253a2ce416e3b98ff771fdfc9e35f4ce31004003e533")),
+            ManagedByteArray::from(&hex!("fdf33783f8de396173fd37b558213117bb2be3430d50b18eeb5da1af0b98fd66")),
+            ManagedByteArray::from(&hex!("889a7d403faae66ec51db6b0708d889ca277e2fd64f78e47612c07077df6eccc")),
+            ManagedByteArray::from(&hex!("5cc55493d05c9bf63431384f184e0cc6ab13c14509c3e9a64dc49b47e3821c6f")),
+            ManagedByteArray::from(&hex!("ca559e91dee09fccf8d3dbf9bda81f57d4094faecf2f9ac3a98e84b3f376c81c")),
+            ManagedByteArray::from(&hex!("781cf1316f87a336a7219095aa8b523a821d260ca0b7a7f94af5c769e17c8f82")),
+            ManagedByteArray::from(&hex!("5e97339ee010d2ae3ac54c38c7158e7a7ef4311f89b28b4634d0d35fd4097dc0")),
+            ManagedByteArray::from(&hex!("2c7b2103c3e48386a7eda174cec726c28ec6ce80466deaac49dbaf469f35d059")),
+            ManagedByteArray::from(&hex!("9b2ceb7809f078724efb71ea3542885c990985d41746d4cab7948928384c3a4c")),
+            ManagedByteArray::from(&hex!("b1f37e46c3f84a3c68804d62b26b7f035c90f344252d77fdeff2393793ae34d4")),
+            ManagedByteArray::from(&hex!("95ead464db14a9a65c3b9c5378cf927b76ff530ae0762dbb6456bfeb467f97b2")),
+            ManagedByteArray::from(&hex!("39e10ed734ddaa3098edc6300edeed2fce75780fc718140359b13c58045a1838")),
+            ManagedByteArray::from(&hex!("b36fbf7a645b24bab3eaca5c351985f6bbb95723b47db78171dd7d7f8883ecad")),
+            ManagedByteArray::from(&hex!("bffe20aa722c488465e18d10ac3abe3002603bbd4c535211d9bd9b34ce7259a1")),
+
+        ])
+    }
+
+
+    pub fn get_first_user_voting_power(&self) -> BigUint<DebugApi> {
+        BigUint::from(managed_biguint!(217433990694))
+    }
+
+    pub fn get_second_user_voting_power(&self) -> BigUint<DebugApi> {
+        BigUint::from(managed_biguint!(59024824840))
+    }
+
+    pub fn get_third_user_voting_power(&self) -> BigUint<DebugApi> {
+        BigUint::from(managed_biguint!(40000000000))
+    }
+
+    pub fn get_merkle_root_hash(&self) -> ManagedByteArray<DebugApi, 32> {
+        ManagedByteArray::from(&hex!("0fdb09afb35351d5becc3a79dd9bf03bae7c2366d186a6c8e8276f545d024ef5"))
     }
 }

--- a/energy-integration/governance-v2/wasm/src/lib.rs
+++ b/energy-integration/governance-v2/wasm/src/lib.rs
@@ -14,18 +14,18 @@ elrond_wasm_node::wasm_endpoints! {
         changeVotingDelayInBlocks
         changeVotingPeriodInBlocks
         depositTokensForProposal
-        downvote
         execute
         getEnergyFactoryAddress
         getLockTimeAfterVotingEndsInBlocks
         getMinEnergyForPropose
         getProposalActions
         getProposalDescription
+        getProposalRootHash
         getProposalStatus
+        getProposalVotes
         getProposer
         getQuorum
-        getTotalDownvotes
-        getTotalVotes
+        getVoteStatus
         getVotingDelayInBlocks
         getVotingPeriodInBlocks
         propose

--- a/energy-integration/governance-v2/wasm/src/lib.rs
+++ b/energy-integration/governance-v2/wasm/src/lib.rs
@@ -25,12 +25,12 @@ elrond_wasm_node::wasm_endpoints! {
         getProposalVotes
         getProposer
         getQuorum
-        getVoteStatus
         getVotingDelayInBlocks
         getVotingPeriodInBlocks
         propose
         queue
         setEnergyFactoryAddress
+        userVotedProposal
         vote
     )
 }


### PR DESCRIPTION
Changed only needed functionality so that instead of energy:
- user sends the voting power himself (before, energy was queried from the energy SC)
- additionally the user needs to pass a correct merkle proof for that VP
- contract verifies the proof against a stored root hash 
Note: When generating the merkle tree, all hashes need to be sorted so that the verification function is as simple as possible
