### PR TITLE
Fees_collector: Set if empty locked_token_id

### DIFF
--- a/energy-integration/fees-collector/src/lib.rs
+++ b/energy-integration/fees-collector/src/lib.rs
@@ -39,7 +39,7 @@ pub trait FeesCollector:
         tokens.push(locked_token_id.clone());
         self.add_known_tokens(tokens);
 
-        self.locked_token_id().set(locked_token_id);
+        self.locked_token_id().set_if_empty(locked_token_id);
         self.energy_factory_address().set(&energy_factory_address);
     }
 


### PR DESCRIPTION
When updating contract, the locked_token_id storage will not be updated.